### PR TITLE
fix(mq): consume timeline debezium topic

### DIFF
--- a/bin/mq.ts
+++ b/bin/mq.ts
@@ -6,6 +6,7 @@ import { handleTimelineMessage } from '@app/lib/timeline/kafka.ts';
 
 const TOPICS = [
   'timeline',
+  'debezium.chii.bangumi.chii_timeline',
   'debezium.chii.bangumi.chii_subjects',
   'debezium.chii.bangumi.chii_subject_revisions',
 ];


### PR DESCRIPTION
## Summary
- subscribe the mq worker to debezium.chii.bangumi.chii_timeline
- route timeline table binlog events to the existing chii_timeline handler by actually consuming that topic

## Validation
- pre-commit lint-staged

## Notes
- no additional build or test commands were run