### PR TITLE
refactor: treat empty env vars as unset

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -76,66 +76,54 @@ impl AppConfig {
 
     let server_from_file = file_config.server.clone().unwrap_or_default();
     let server = ServerConfig {
-      host: env::var("HOST")
-        .ok()
+      host: env_var("HOST")
         .or(server_from_file.host)
         .unwrap_or_else(|| "0.0.0.0".to_owned()),
-      port: env::var("PORT")
-        .ok()
+      port: env_var("PORT")
         .and_then(|value| value.parse::<u16>().ok())
         .or(server_from_file.port)
         .unwrap_or(4000),
     };
 
-    let redis_uri = env::var("REDIS_URI")
-      .ok()
+    let redis_uri = env_var("REDIS_URI")
       .or(file_config.redis_uri.clone())
       .unwrap_or_else(|| "redis://127.0.0.1:3306/0".to_owned());
 
-    let kafka_brokers = env::var("KAFKA_BROKERS")
-      .ok()
+    let kafka_brokers = env_var("KAFKA_BROKERS")
       .or(file_config.kafka_brokers.clone())
       .unwrap_or_else(|| "127.0.0.1:9092".to_owned());
 
-    let kafka_rust_mq_group_id = env::var("KAFKA_RUST_MQ_GROUP_ID")
-      .ok()
+    let kafka_rust_mq_group_id = env_var("KAFKA_RUST_MQ_GROUP_ID")
       .or(file_config.kafka_rust_mq_group_id.clone())
       .unwrap_or_else(|| "server-private-rust-mq".to_owned());
 
     let mysql_from_file = file_config.mysql.clone().unwrap_or_default();
     let mysql = MySqlConfig {
-      host: env::var("MYSQL_HOST")
-        .ok()
+      host: env_var("MYSQL_HOST")
         .or(mysql_from_file.host)
         .unwrap_or_else(|| "127.0.0.1".to_owned()),
-      port: env::var("MYSQL_PORT")
-        .ok()
+      port: env_var("MYSQL_PORT")
         .and_then(|value| value.parse::<u16>().ok())
         .or(mysql_from_file.port)
         .unwrap_or(3306),
-      user: env::var("MYSQL_USER")
-        .ok()
+      user: env_var("MYSQL_USER")
         .or(mysql_from_file.user)
         .unwrap_or_else(|| "user".to_owned()),
-      password: env::var("MYSQL_PASS")
-        .ok()
+      password: env_var("MYSQL_PASS")
         .or(mysql_from_file.password)
         .unwrap_or_else(|| "password".to_owned()),
-      db: env::var("MYSQL_DB")
-        .ok()
+      db: env_var("MYSQL_DB")
         .or(mysql_from_file.db)
         .unwrap_or_else(|| "bangumi".to_owned()),
     };
 
-    let cookie_secret_token = env::var("COOKIE_SECRET_TOKEN")
-      .ok()
+    let cookie_secret_token = env_var("COOKIE_SECRET_TOKEN")
       .or(file_config.cookie_secret_token)
       .unwrap_or_else(|| {
         "insecure-cookie-secret-token-change-me-in-production".to_owned()
       });
 
-    let php_session_secret_key = env::var("PHP_SESSION_SECRET_KEY")
-      .ok()
+    let php_session_secret_key = env_var("PHP_SESSION_SECRET_KEY")
       .or(file_config.php_session_secret_key)
       .unwrap_or_else(|| "default-secret-key-not-safe-in-production".to_owned());
 
@@ -149,6 +137,10 @@ impl AppConfig {
       php_session_secret_key,
     })
   }
+}
+
+fn env_var(key: &str) -> Option<String> {
+  env::var(key).ok().filter(|value| !value.trim().is_empty())
 }
 
 fn config_path() -> PathBuf {


### PR DESCRIPTION
## Summary
- add nv_var() helper to centralize environment variable reads
- treat empty/whitespace-only env var values as unset
- apply helper across all config env lookups including Kafka group id

## Behavior
When an env var is set to an empty string (or whitespace only), config now falls back to file config/defaults, same as if the env var is not set.