### PR TITLE
feat: return locked and redirect fields in wiki GET endpoint for character

### DIFF
--- a/routes/__snapshots__/index.test.ts.snap
+++ b/routes/__snapshots__/index.test.ts.snap
@@ -346,8 +346,12 @@ exports[`should build private api spec 1`] = `
           type: integer
         infobox:
           type: string
+        locked:
+          type: boolean
         name:
           type: string
+        redirect:
+          type: integer
         summary:
           type: string
       required:
@@ -355,6 +359,8 @@ exports[`should build private api spec 1`] = `
         - name
         - infobox
         - summary
+        - locked
+        - redirect
       type: object
     CollectSubject:
       properties:

--- a/routes/private/routes/wiki/character/index.spec.ts
+++ b/routes/private/routes/wiki/character/index.spec.ts
@@ -59,7 +59,9 @@ describe('edit character ', () => {
       }
       |声优=
       }}",
+        "locked": false,
         "name": "坂上智代",
+        "redirect": 0,
         "summary": "朋也的后辈……虽说应当是如此，说起话来的口气却像是个前辈一样。她待人很好，又有领导才能，因此在她的身边很自然地就聚集起了许多人。她的目标是成为学生会的会长，但这却成为了她与朋也之间的鸿沟……",
       }
     `);
@@ -161,7 +163,9 @@ describe('edit character ', () => {
       Object {
         "id": 40,
         "infobox": "i",
+        "locked": false,
         "name": "n",
+        "redirect": 0,
         "summary": "s",
       }
     `);

--- a/routes/private/routes/wiki/character/index.ts
+++ b/routes/private/routes/wiki/character/index.ts
@@ -25,6 +25,8 @@ export const CharacterWikiInfo = t.Object(
     name: t.String(),
     infobox: t.String(),
     summary: t.String(),
+    locked: t.Boolean(),
+    redirect: t.Integer(),
   },
   { $id: 'CharacterWikiInfo' },
 );
@@ -150,15 +152,13 @@ export async function setup(app: App) {
         throw new NotFoundError(`character ${characterID}`);
       }
 
-      if (c.lock) {
-        throw new NotAllowedError('edit a locked character');
-      }
-
       return {
         id: c.id,
         name: c.name,
         infobox: c.infobox,
         summary: c.summary,
+        locked: Boolean(c.ban),
+        redirect: c.redirect,
       };
     },
   );


### PR DESCRIPTION
Follow-up to #1550, applying the same pattern to the character wiki GET endpoint.\n\n## Changes\n\n- Add \locked: boolean\ and \edirect: integer\ fields to GET \/p1/wiki/characters/:id\ response\n- Remove throwing 403 error when character is locked\n\nDownstream clients can now distinguish:\n- **Normal**: \locked === false && redirect === 0\\n- **Locked**: \locked === true\ (\an !== 0\)\n- **Redirect**: \edirect !== 0\ (target character ID)