### PR TITLE
fix: replace deprecated toBeCalledWith with toHaveBeenCalledWith

### DIFF
--- a/routes/private/routes/wiki/subject/subject.test.ts
+++ b/routes/private/routes/wiki/subject/subject.test.ts
@@ -297,7 +297,7 @@ describe('edit subject ', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(editSubject).toBeCalledWith({
+    expect(editSubject).toHaveBeenCalledWith({
       commitMessage: 'c',
       infobox: 'i',
       name: 'n',
@@ -411,7 +411,7 @@ describe('should upload image', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(uploadImageMock).toBeCalledWith(
+    expect(uploadImageMock).toHaveBeenCalledWith(
       expect.stringMatching(/.*\.jpe?g$/),
       expect.objectContaining({}),
     );


### PR DESCRIPTION
Fixes the lint failure in #1552. `@typescript-eslint` v8.57.1 (introduced in the renovate pin PR) treats \	oBeCalledWith\ as deprecated in favour of \	oHaveBeenCalledWith\.