### PR TITLE
fix: use correct naming pattern for character/person image uploads

### DIFF
--- a/routes/private/routes/wiki/character/index.test.ts
+++ b/routes/private/routes/wiki/character/index.test.ts
@@ -218,7 +218,7 @@ describe('edit character ', () => {
 
     expect(res.statusCode).toBe(200);
     const imageRes = res.json();
-    expect(imageRes.img).toMatch(/^raw(?:\/\w{2}){2}\/40_.*\.jpe?g$/);
+    expect(imageRes.img).toMatch(/^raw(?:\/\w{2}){2}\/40_crt_.*\.jpe?g$/);
 
     expect(uploadImageMock).toHaveBeenCalledWith(
       expect.stringMatching(/.*\.jpe?g$/),

--- a/routes/private/routes/wiki/character/index.ts
+++ b/routes/private/routes/wiki/character/index.ts
@@ -335,8 +335,8 @@ export async function setup(app: App) {
       // for example "36b8f84d-df4e-4d49-b662-bcde71a8764f"
       const h = crypto.randomUUID();
 
-      // for example raw/36/b8/${character_id}_36b8f84d-df4e-4d49-b662-bcde71a8764f.jpg"
-      const filename = `raw/${h.slice(0, 2)}/${h.slice(2, 4)}/${characterID}_${h}.${ext}`;
+      // for example raw/36/b8/${character_id}_crt_36b8f84d-df4e-4d49-b662-bcde71a8764f.jpg"
+      const filename = `raw/${h.slice(0, 2)}/${h.slice(2, 4)}/${characterID}_crt_${h}.${ext}`;
 
       await db.transaction(async (t) => {
         await t

--- a/routes/private/routes/wiki/person/index.test.ts
+++ b/routes/private/routes/wiki/person/index.test.ts
@@ -276,7 +276,7 @@ describe('edit person ', () => {
 
     expect(res.statusCode).toBe(200);
     const imageRes = res.json();
-    expect(imageRes.img).toMatch(/^raw(?:\/\w{2}){2}\/3214_.*\.jpe?g$/);
+    expect(imageRes.img).toMatch(/^raw(?:\/\w{2}){2}\/3214_prsn_.*\.jpe?g$/);
 
     expect(uploadImageMock).toHaveBeenCalledWith(
       expect.stringMatching(/.*\.jpe?g$/),

--- a/routes/private/routes/wiki/person/index.ts
+++ b/routes/private/routes/wiki/person/index.ts
@@ -370,8 +370,8 @@ export async function setup(app: App) {
       // for example "36b8f84d-df4e-4d49-b662-bcde71a8764f"
       const h = crypto.randomUUID();
 
-      // for example raw/36/b8/${person_id}_36b8f84d-df4e-4d49-b662-bcde71a8764f.jpg"
-      const filename = `raw/${h.slice(0, 2)}/${h.slice(2, 4)}/${personID}_${h}.${ext}`;
+      // for example raw/36/b8/${person_id}_prsn_36b8f84d-df4e-4d49-b662-bcde71a8764f.jpg"
+      const filename = `raw/${h.slice(0, 2)}/${h.slice(2, 4)}/${personID}_prsn_${h}.${ext}`;
 
       await db.transaction(async (t) => {
         await t


### PR DESCRIPTION
角色和人物图片命名改为与之前风格一致的格式：

- Character: \\_crt_\.\\
- Person: \\_prsn_\.\\

Closes #1574