### PR TITLE
feat: add notification types for character/person patch and patch reply

### DIFF
--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -54,6 +54,16 @@ export const NotifyType = Object.freeze({
   EpisodePatchRejected: 38,
   SubjectPatchExpired: 39,
   EpisodePatchExpired: 40,
+  CharacterPatchAccepted: 41,
+  PersonPatchAccepted: 42,
+  CharacterPatchRejected: 43,
+  PersonPatchRejected: 44,
+  CharacterPatchExpired: 45,
+  PersonPatchExpired: 46,
+  SubjectPatchReply: 47,
+  EpisodePatchReply: 48,
+  CharacterPatchReply: 49,
+  PersonPatchReply: 50,
 });
 
 export type NotifyType = (typeof NotifyType)[keyof typeof NotifyType];
@@ -678,6 +688,115 @@ const _settings: Record<number, setting> = {
     suffix: '',
     id: 40,
     hash: 22,
+    merge: 1,
+  },
+
+  '41': {
+    url: 'https://patch.bgm38.tv/c/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix:
+      '你的角色 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 已经被接受',
+    suffix: '',
+    id: 41,
+    hash: 23,
+    merge: 1,
+  },
+  '42': {
+    url: 'https://patch.bgm38.tv/p/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix:
+      '你的人物 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 已经被接受',
+    suffix: '',
+    id: 42,
+    hash: 24,
+    merge: 1,
+  },
+  '43': {
+    url: 'https://patch.bgm38.tv/c/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix:
+      '你的角色 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 已经被拒绝',
+    suffix: '',
+    id: 43,
+    hash: 23,
+    merge: 1,
+  },
+  '44': {
+    url: 'https://patch.bgm38.tv/p/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix:
+      '你的人物 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 已经被拒绝',
+    suffix: '',
+    id: 44,
+    hash: 24,
+    merge: 1,
+  },
+  '45': {
+    url: 'https://patch.bgm38.tv/c/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix: '你的角色 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 已经过期',
+    suffix: '',
+    id: 45,
+    hash: 23,
+    merge: 1,
+  },
+  '46': {
+    url: 'https://patch.bgm38.tv/p/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix: '你的人物 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 已经过期',
+    suffix: '',
+    id: 46,
+    hash: 24,
+    merge: 1,
+  },
+  '47': {
+    url: 'https://patch.bgm38.tv/s/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix:
+      '你参与的条目 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 有新回复',
+    suffix: '',
+    id: 47,
+    hash: 21,
+    merge: 1,
+  },
+  '48': {
+    url: 'https://patch.bgm38.tv/e/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix:
+      '你参与的章节 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 有新回复',
+    suffix: '',
+    id: 48,
+    hash: 22,
+    merge: 1,
+  },
+  '49': {
+    url: 'https://patch.bgm38.tv/c/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix:
+      '你参与的角色 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 有新回复',
+    suffix: '',
+    id: 49,
+    hash: 23,
+    merge: 1,
+  },
+  '50': {
+    url: 'https://patch.bgm38.tv/p/',
+    anchor: '#',
+    // util.format expects args: url, path, hash, title
+    prefix:
+      '你参与的人物 patch <a href="%s%s" class="nt_link link_%s" target="_blank">%s</a> 有新回复',
+    suffix: '',
+    id: 50,
+    hash: 24,
     merge: 1,
   },
 };


### PR DESCRIPTION
Add notification types 41-50 in lib/notify.ts:

- 41: CharacterPatchAccepted (hash 23, /c/)
- 42: PersonPatchAccepted (hash 24, /p/)
- 43: CharacterPatchRejected (hash 23, /c/)
- 44: PersonPatchRejected (hash 24, /p/)
- 45: CharacterPatchExpired (hash 23, /c/)
- 46: PersonPatchExpired (hash 24, /p/)
- 47: SubjectPatchReply (hash 21, /s/)
- 48: EpisodePatchReply (hash 22, /e/)
- 49: CharacterPatchReply (hash 23, /c/)
- 50: PersonPatchReply (hash 24, /p/)

Uses existing notify.v1 Kafka consumer and buf-generated protobuf parser.