### PR TITLE
allow oauth-backend turnstile callback

### DIFF
--- a/routes/private/routes/auth.ts
+++ b/routes/private/routes/auth.ts
@@ -39,6 +39,7 @@ const allowedRedirectUris: string[] = [
   'bangulite://turnstile/callback',
   // https://www.anix.app
   'anix://tv.bgm/turnstile',
+  'https://oauth-backend-jet.vercel.app/api/turnstile/callback',
 ];
 
 // eslint-disable-next-line @typescript-eslint/require-await


### PR DESCRIPTION
申请重定向白名单加入bgm-cli的后端

bgm-cli为新private api提供了一系列兼容的命令行操作，项目地址为 https://github.com/aronnaxlin/bgm-cli

在班固米的宣传帖子在 https://bangumi.tv/group/topic/456468