### PR TITLE
fix: use fresh DB data for group topics listing instead of stale Redis cache

### DIFF
--- a/routes/private/routes/group.ts
+++ b/routes/private/routes/group.ts
@@ -396,7 +396,14 @@ export async function setup(app: App) {
       if (tids.length === 0) {
         return { total: 0, data: [] };
       }
-      const topics = await fetcher.fetchGroupTopicsByIDs(tids);
+      const topicRows = await db
+        .select()
+        .from(schema.chiiGroupTopics)
+        .where(op.inArray(schema.chiiGroupTopics.id, tids));
+      const topics: Record<number, res.ITopic> = {};
+      for (const d of topicRows) {
+        topics[d.id] = convert.toGroupTopic(d);
+      }
       const uids = Object.values(topics).map((d) => d.creatorID);
       const users = await fetcher.fetchSlimUsersByIDs(uids);
       const gids = Object.values(topics).map((d) => d.parentID);


### PR DESCRIPTION
## Summary

- /groups/-/topics endpoint was using etchGroupTopicsByIDs() which reads from Redis cache
- When the cache had stale data (e.g. eplyCount=0 from initial cache population), the endpoint returned incorrect values
- The per-group endpoint /groups/:groupName/topics reads directly from DB and always returns correct values
- This change makes the recent group topics endpoint query the DB directly, consistent with the per-group endpoint

Fixes #1623