### PR TITLE
feat(cron): add daemon and run subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ static/style
 !.yarn/plugins
 changelog.md
 
-.codex
+.codex/

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ static/style
 !.yarn/plugins
 changelog.md
 
-.codex/
+.codex

--- a/bin/cron.ts
+++ b/bin/cron.ts
@@ -1,3 +1,6 @@
+import * as console from 'node:console';
+import * as process from 'node:process';
+
 import { CronJob } from 'cron';
 
 import { logger } from '@app/lib/logger';
@@ -23,6 +26,25 @@ interface CronJobContext {
   name: string;
 }
 
+const jobsConfig: { name: string; cronTime: string; func: () => Promise<void> }[] = [
+  { name: 'heartbeat', cronTime: '*/10 * * * * *', func: heartbeat },
+  { name: 'trendingSubjects', cronTime: '0 0 3 * * *', func: trendingSubjects },
+  { name: 'trendingSubjectTopics', cronTime: '0 */10 * * * *', func: trendingSubjectTopics },
+  {
+    name: 'truncateTimelineGlobalCache',
+    cronTime: '*/10 * * * *',
+    func: truncateTimelineGlobalCache,
+  },
+  { name: 'truncateTimelineInboxCache', cronTime: '0 0 4 * * *', func: truncateTimelineInboxCache },
+  { name: 'truncateTimelineUserCache', cronTime: '0 0 5 * * *', func: truncateTimelineUserCache },
+  { name: 'cleanupExpiredAccessTokens', cronTime: '0 0 6 * * *', func: cleanupExpiredAccessTokens },
+  {
+    name: 'cleanupExpiredRefreshTokens',
+    cronTime: '0 0 7 * * *',
+    func: cleanupExpiredRefreshTokens,
+  },
+];
+
 function newCronJob(
   name: string,
   cronTime: string,
@@ -46,16 +68,51 @@ function newCronJob(
 }
 
 function main() {
-  const jobs: CronJob<null, CronJobContext>[] = [
-    newCronJob('heartbeat', '*/10 * * * * *', heartbeat),
-    newCronJob('trendingSubjects', '0 0 3 * * *', trendingSubjects),
-    newCronJob('trendingSubjectTopics', '0 */10 * * * *', trendingSubjectTopics),
-    newCronJob('truncateTimelineGlobalCache', '*/10 * * * *', truncateTimelineGlobalCache),
-    newCronJob('truncateTimelineInboxCache', '0 0 4 * * *', truncateTimelineInboxCache),
-    newCronJob('truncateTimelineUserCache', '0 0 5 * * *', truncateTimelineUserCache),
-    newCronJob('cleanupExpiredAccessTokens', '0 0 6 * * *', cleanupExpiredAccessTokens),
-    newCronJob('cleanupExpiredRefreshTokens', '0 0 7 * * *', cleanupExpiredRefreshTokens),
-  ];
+  const command = process.argv[2];
+
+  if (command === 'run') {
+    const jobName = process.argv[3];
+    if (!jobName) {
+      console.error('Usage: cron run <job-name>');
+      console.error(`Available jobs: ${jobsConfig.map((j) => j.name).join(', ')}`);
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(1);
+    }
+
+    const config = jobsConfig.find((j) => j.name === jobName);
+    if (!config) {
+      console.error(`Unknown job: ${jobName}`);
+      console.error(`Available jobs: ${jobsConfig.map((j) => j.name).join(', ')}`);
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(1);
+    }
+
+    logger.info(`Running job "${jobName}" manually...`);
+    config
+      .func()
+      .then(() => {
+        logger.info(`Job "${jobName}" completed.`);
+        // eslint-disable-next-line unicorn/no-process-exit
+        process.exit(0);
+      })
+      .catch((error: unknown) => {
+        logger.error(error, `Job "${jobName}" failed.`);
+        // eslint-disable-next-line unicorn/no-process-exit
+        process.exit(1);
+      });
+    return;
+  }
+
+  if (command && command !== 'daemon') {
+    console.error(`Unknown command: ${command}`);
+    console.error('Usage: cron <daemon|run <job-name>>');
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  }
+
+  const jobs: CronJob<null, CronJobContext>[] = jobsConfig.map((j) =>
+    newCronJob(j.name, j.cronTime, j.func),
+  );
   for (const job of jobs) {
     logger.info(`Cronjob: ${job.context.name} @ ${job.cronTime.source}`);
     job.start();


### PR DESCRIPTION
Allow manually triggering individual cron jobs without starting the full scheduler.

Usage:

    bin/cron.ts daemon                 # start all jobs on schedule
    bin/cron.ts run trendingSubjects   # run a single job once

Available jobs: heartbeat, trendingSubjects, trendingSubjectTopics, truncateTimelineGlobalCache, truncateTimelineInboxCache, truncateTimelineUserCache, cleanupExpiredAccessTokens, cleanupExpiredRefreshTokens

closes #1206