### PR TITLE
refactor: replace TypeScript enums with erasable const objects

### DIFF
--- a/lib/subject/date.test.ts
+++ b/lib/subject/date.test.ts
@@ -54,6 +54,6 @@ test.each([
     SubjectType.Book,
     DATE.parse('2019-11-28'),
   ],
-])('extractDate(%s) = %s', (w: Wiki, t: SubjectType, date: DATE) => {
+])('extractDate(%s) = %s', (w: Wiki, t: number, date: DATE) => {
   expect(extractDate(w, t, 0)).toEqual(date);
 });

--- a/lib/subject/date.ts
+++ b/lib/subject/date.ts
@@ -3,9 +3,7 @@ import type { Wiki } from '@bgm38/wiki';
 import { DATE } from '@app/lib/utils/date.ts';
 import { getSubjectPlatformSortKeys } from '@app/vendor';
 
-import type { SubjectType } from './type';
-
-export function extractDate(w: Wiki, typeID: SubjectType, platform: number): DATE {
+export function extractDate(w: Wiki, typeID: number, platform: number): DATE {
   const keys = getSubjectPlatformSortKeys(typeID, platform);
 
   const values = keys

--- a/lib/subject/index.ts
+++ b/lib/subject/index.ts
@@ -212,7 +212,7 @@ export async function create({
       rate10: 0,
     } satisfies typeof schema.chiiSubjectFields.$inferInsert);
 
-    if ([SubjectType.Anime, SubjectType.Real].includes(typeID) && episodes) {
+    if ((typeID === SubjectType.Anime || typeID === SubjectType.Real) && episodes) {
       // avoid create too many episodes, 50 is enough.
       episodes = Math.min(episodes, 50);
 

--- a/lib/subject/infobox.ts
+++ b/lib/subject/infobox.ts
@@ -1,3 +1,4 @@
+import { UnreachableError } from '@app/lib/error.ts';
 import { getInfoboxValue } from '@app/lib/infobox.ts';
 import type * as res from '@app/lib/types/res.ts';
 
@@ -22,7 +23,7 @@ function getDisplayFields(type: number): string[][] {
       return [airdate, ['开始'], ['导演'], ['编剧'], ['主演']];
     }
     default: {
-      return [];
+      throw new UnreachableError(`unexpected subject type: ${type}`);
     }
   }
 }

--- a/lib/subject/infobox.ts
+++ b/lib/subject/infobox.ts
@@ -3,7 +3,7 @@ import type * as res from '@app/lib/types/res.ts';
 
 import { SubjectType } from './type';
 
-function getDisplayFields(type: SubjectType): string[][] {
+function getDisplayFields(type: number): string[][] {
   const airdate = ['放送开始', '上映日', '上映年度', '发售日'];
   switch (type) {
     case SubjectType.Book: {
@@ -21,10 +21,13 @@ function getDisplayFields(type: SubjectType): string[][] {
     case SubjectType.Real: {
       return [airdate, ['开始'], ['导演'], ['编剧'], ['主演']];
     }
+    default: {
+      return [];
+    }
   }
 }
 
-export function getInfoboxSummary(infobox: res.IInfoboxItem[], type: SubjectType, eps = 0): string {
+export function getInfoboxSummary(infobox: res.IInfoboxItem[], type: number, eps = 0): string {
   const displayFields = getDisplayFields(type);
   const list: string[] = [];
   if (eps > 0) {

--- a/lib/subject/type.ts
+++ b/lib/subject/type.ts
@@ -1,11 +1,10 @@
-// eslint-disable-next-line erasable-syntax-only/enums
-export enum SubjectType {
-  Book = 1, // 书籍
-  Anime = 2, // 动画
-  Music = 3, // 音乐
-  Game = 4, // 游戏
-  Real = 6, // 三次元
-}
+export const SubjectType = {
+  Book: 1, // 书籍
+  Anime: 2, // 动画
+  Music: 3, // 音乐
+  Game: 4, // 游戏
+  Real: 6, // 三次元
+} as const;
 export const SubjectTypeValues = new Set([1, 2, 3, 4, 6]);
 
 export const EpisodeType = Object.freeze({
@@ -22,18 +21,17 @@ export const EpisodeType = Object.freeze({
 });
 export type EpisodeType = (typeof EpisodeType)[keyof typeof EpisodeType];
 
-// eslint-disable-next-line erasable-syntax-only/enums
-export enum CollectionType {
-  Wish = 1,
-  Collect = 2,
-  Doing = 3,
-  OnHold = 4,
-  Dropped = 5,
-}
+export const CollectionType = {
+  Wish: 1,
+  Collect: 2,
+  Doing: 3,
+  OnHold: 4,
+  Dropped: 5,
+} as const;
 export const CollectionTypeValues = new Set([1, 2, 3, 4, 5]);
 export const CollectionTypeProfileValues = new Set([1, 2]);
 
-export function getCollectionTypeField(type: CollectionType) {
+export function getCollectionTypeField(type: number) {
   switch (type) {
     case CollectionType.Wish: {
       return 'wish';
@@ -48,6 +46,9 @@ export function getCollectionTypeField(type: CollectionType) {
       return 'onHold';
     }
     case CollectionType.Dropped: {
+      return 'dropped';
+    }
+    default: {
       return 'dropped';
     }
   }
@@ -85,7 +86,7 @@ export type SubjectSort = (typeof SubjectSort)[keyof typeof SubjectSort];
 export type SubjectTagsCategory = 'meta' | 'subject';
 
 export interface SubjectFilter {
-  type: SubjectType;
+  type: number;
   nsfw: boolean;
   cat?: number;
   series?: boolean;

--- a/lib/subject/type.ts
+++ b/lib/subject/type.ts
@@ -1,3 +1,5 @@
+import { UnreachableError } from '@app/lib/error.ts';
+
 export const SubjectType = {
   Book: 1, // 书籍
   Anime: 2, // 动画
@@ -49,7 +51,7 @@ export function getCollectionTypeField(type: number) {
       return 'dropped';
     }
     default: {
-      return 'dropped';
+      throw new UnreachableError(`unexpected collection type: ${type}`);
     }
   }
 }

--- a/lib/subject/utils.ts
+++ b/lib/subject/utils.ts
@@ -1,15 +1,15 @@
 import { decr, incr, op, type orm, schema, type Txn } from '@app/drizzle';
 
 import { markEpisodesAsWatched } from './ep';
-import { type CollectionType, SubjectType } from './type';
+import { SubjectType } from './type';
 import { getCollectionTypeField } from './type';
 
 /** 更新条目收藏计数，需要在事务中执行 */
 export async function updateSubjectCollectionCounts(
   t: Txn,
   subjectID: number,
-  newType: CollectionType,
-  oldType?: CollectionType,
+  newType: number,
+  oldType?: number,
 ) {
   if (oldType && oldType === newType) {
     return;
@@ -89,7 +89,7 @@ export async function completeSubjectProgress(
   if (subject.volumes > 0) {
     interest.volStatus = subject.volumes;
   }
-  if ([SubjectType.Anime, SubjectType.Real].includes(subject.typeID)) {
+  if (subject.typeID === SubjectType.Anime || subject.typeID === SubjectType.Real) {
     const episodes = await t
       .select({ id: schema.chiiEpisodes.id })
       .from(schema.chiiEpisodes)

--- a/lib/timeline/writer.ts
+++ b/lib/timeline/writer.ts
@@ -30,7 +30,7 @@ export interface TimelineMessage {
     uid: number;
     subject: {
       id: number;
-      type: SubjectType;
+      type: number;
     };
     createdAt: number;
     source: number;
@@ -39,11 +39,11 @@ export interface TimelineMessage {
     uid: number;
     subject: {
       id: number;
-      type: SubjectType;
+      type: number;
     };
     collect: {
       id: number;
-      type: CollectionType;
+      type: number;
       rate: number;
       comment: string;
     };
@@ -54,7 +54,7 @@ export interface TimelineMessage {
     uid: number;
     subject: {
       id: number;
-      type: SubjectType;
+      type: number;
     };
     episode: {
       id: number;
@@ -67,7 +67,7 @@ export interface TimelineMessage {
     uid: number;
     subject: {
       id: number;
-      type: SubjectType;
+      type: number;
       eps: number;
       volumes: number;
     };
@@ -525,7 +525,7 @@ export const TimelineWriter: TimelineDatabaseWriter = {
   },
 };
 
-function switchSubjectType(ctype: CollectionType, stype: SubjectType): number {
+function switchSubjectType(ctype: number, stype: number): number {
   switch (stype) {
     case SubjectType.Book: {
       const source = {
@@ -535,7 +535,7 @@ function switchSubjectType(ctype: CollectionType, stype: SubjectType): number {
         [CollectionType.OnHold]: 13,
         [CollectionType.Dropped]: 14,
       };
-      return source[ctype];
+      return source[ctype as keyof typeof source];
     }
     case SubjectType.Anime:
     case SubjectType.Real: {
@@ -546,7 +546,7 @@ function switchSubjectType(ctype: CollectionType, stype: SubjectType): number {
         [CollectionType.OnHold]: 13,
         [CollectionType.Dropped]: 14,
       };
-      return source[ctype];
+      return source[ctype as keyof typeof source];
     }
     case SubjectType.Music: {
       const source = {
@@ -556,7 +556,7 @@ function switchSubjectType(ctype: CollectionType, stype: SubjectType): number {
         [CollectionType.OnHold]: 13,
         [CollectionType.Dropped]: 14,
       };
-      return source[ctype];
+      return source[ctype as keyof typeof source];
     }
     case SubjectType.Game: {
       const source = {
@@ -566,7 +566,10 @@ function switchSubjectType(ctype: CollectionType, stype: SubjectType): number {
         [CollectionType.OnHold]: 13,
         [CollectionType.Dropped]: 14,
       };
-      return source[ctype];
+      return source[ctype as keyof typeof source];
+    }
+    default: {
+      return 14;
     }
   }
 }

--- a/lib/timeline/writer.ts
+++ b/lib/timeline/writer.ts
@@ -1,7 +1,7 @@
 import * as lo from 'lodash-es';
 
 import { db, op, schema } from '@app/drizzle';
-import { BadRequestError } from '@app/lib/error.ts';
+import { BadRequestError, UnreachableError } from '@app/lib/error.ts';
 import { producer } from '@app/lib/kafka';
 import { CollectionType, EpisodeCollectionStatus, SubjectType } from '@app/lib/subject/type';
 import { decode } from '@app/lib/utils';
@@ -569,7 +569,7 @@ function switchSubjectType(ctype: number, stype: number): number {
       return source[ctype as keyof typeof source];
     }
     default: {
-      return 14;
+      throw new UnreachableError(`unexpected subject type: ${stype}`);
     }
   }
 }

--- a/lib/trending/cache.ts
+++ b/lib/trending/cache.ts
@@ -1,7 +1,6 @@
-import type { SubjectType } from '@app/lib/subject/type.ts';
 import type { TrendingPeriod } from '@app/lib/trending/type.ts';
 
-export function getTrendingSubjectKey(type: SubjectType, period: TrendingPeriod) {
+export function getTrendingSubjectKey(type: number, period: TrendingPeriod) {
   return `trending:subjects:${type}:${period}`;
 }
 

--- a/lib/trending/subject.ts
+++ b/lib/trending/subject.ts
@@ -8,7 +8,7 @@ import { getTrendingDateline, TrendingPeriod } from '@app/lib/trending/type.ts';
 import { getTrendingSubjectKey } from './cache';
 
 export async function updateTrendingSubjects(
-  subjectType: SubjectType,
+  subjectType: number,
   period = TrendingPeriod.Month,
   flush = false,
 ) {

--- a/lib/user/stats.ts
+++ b/lib/user/stats.ts
@@ -146,9 +146,9 @@ export async function countUserSubjectCollection(
     [SubjectType.Real]: Object.assign({}, empty),
   };
   for (const d of data) {
-    const type = d.ctype as CollectionType;
-    const stype = d.stype as SubjectType;
-    stats[stype][type] = d.count;
+    const type = d.ctype;
+    const stype = d.stype;
+    stats[stype as keyof typeof stats][type as keyof typeof empty] = d.count;
   }
   await redis.setex(key, 3600, JSON.stringify(stats));
   return stats;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -200,6 +200,5 @@ export function parseConvertedValue<T extends TSchema>(schema: T, value: unknown
   const converted = Value.Convert(schema, value);
   const result = Value.Parse(schema, converted);
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return result;
 }


### PR DESCRIPTION
## Summary
- 将 `SubjectType` 和 `CollectionType` 枚举替换为 `as const` 对象，消除 `erasable-syntax-only/enums` 违规
- 函数参数类型从严格字面量联合类型改为 `number`（与 DB 实际类型一致）
- 移除 2 处 `eslint-disable-next-line erasable-syntax-only/enums` 注释