### PR TITLE
feat: add privacy settings api

### DIFF
--- a/bin/mq.ts
+++ b/bin/mq.ts
@@ -17,7 +17,11 @@ import {
 } from '@app/event/subject';
 import { handle as handleTimelineEvent } from '@app/event/timeline';
 import type { KafkaMessage, Payload } from '@app/event/type';
-import { handle as handleUserEvent, handleFriend as handleFriendEvent } from '@app/event/user';
+import {
+  handle as handleUserEvent,
+  handleFields as handleUserFieldsEvent,
+  handleFriend as handleFriendEvent,
+} from '@app/event/user';
 import { newConsumer } from '@app/lib/kafka.ts';
 import { logger } from '@app/lib/logger';
 import { handleTimelineMessage } from '@app/lib/timeline/kafka.ts';
@@ -35,6 +39,7 @@ const TOPICS = [
   'debezium.chii.bangumi.chii_group_members',
   'debezium.chii.bangumi.chii_group_topics',
   'debezium.chii.bangumi.chii_index',
+  'debezium.chii.bangumi.chii_memberfields',
   'debezium.chii.bangumi.chii_members',
   'debezium.chii.bangumi.chii_friends',
   'debezium.chii.bangumi.chii_persons',
@@ -55,6 +60,7 @@ const binlogHandlers: Record<string, Handler | Handler[]> = {
   chii_group_members: handleGroupMemberEvent,
   chii_group_topics: handleGroupTopicEvent,
   chii_index: handleIndexEvent,
+  chii_memberfields: handleUserFieldsEvent,
   chii_members: handleUserEvent,
   chii_friends: handleFriendEvent,
   chii_persons: handlePersonEvent,

--- a/event/user.ts
+++ b/event/user.ts
@@ -2,10 +2,10 @@ import redis from '@app/lib/redis.ts';
 import {
   getFollowersCacheKey,
   getFriendsCacheKey,
+  getPrivacyCacheKey,
   getRelationCacheKey,
   getSlimCacheKey,
 } from '@app/lib/user/cache';
-import { clearCachedPrivacyByUserID } from '@app/lib/user/privacy.ts';
 
 import { EventOp, type KafkaMessage } from './type';
 
@@ -42,7 +42,7 @@ export async function handleFields({ key, value }: KafkaMessage) {
     case EventOp.Create:
     case EventOp.Update:
     case EventOp.Delete: {
-      await clearCachedPrivacyByUserID(idx.uid);
+      await redis.del(getPrivacyCacheKey(idx.uid));
       break;
     }
     case EventOp.Snapshot: {

--- a/event/user.ts
+++ b/event/user.ts
@@ -5,6 +5,7 @@ import {
   getRelationCacheKey,
   getSlimCacheKey,
 } from '@app/lib/user/cache';
+import { clearCachedPrivacyByUserID } from '@app/lib/user/privacy.ts';
 
 import { EventOp, type KafkaMessage } from './type';
 
@@ -26,6 +27,22 @@ export async function handle({ key, value }: KafkaMessage) {
     case EventOp.Update:
     case EventOp.Delete: {
       await redis.del(getSlimCacheKey(idx.uid));
+      break;
+    }
+    case EventOp.Snapshot: {
+      break;
+    }
+  }
+}
+
+export async function handleFields({ key, value }: KafkaMessage) {
+  const idx = JSON.parse(key) as UserKey;
+  const payload = JSON.parse(value.toString()) as UserPayload;
+  switch (payload.op) {
+    case EventOp.Create:
+    case EventOp.Update:
+    case EventOp.Delete: {
+      await clearCachedPrivacyByUserID(idx.uid);
       break;
     }
     case EventOp.Snapshot: {

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -2,12 +2,16 @@ import * as crypto from 'node:crypto';
 
 import { createError } from '@fastify/error';
 import { compare } from '@node-rs/bcrypt';
-import { DateTime } from 'luxon';
 
 import { db, op, schema } from '@app/drizzle';
 import { TypedCache } from '@app/lib/cache.ts';
 import type * as res from '@app/lib/types/res.ts';
 import { fetchPermission, type Permission } from '@app/lib/user/perm';
+import {
+  canViewNsfwSubject,
+  fetchPrivacyByUserID,
+  isNsfwSubjectPreferenceEnabled,
+} from '@app/lib/user/privacy.ts';
 import { fetchUserX } from '@app/lib/user/utils.ts';
 import { intval } from '@app/lib/utils/index.ts';
 import { getTimelineSourceFromAppID } from '@app/vendor';
@@ -51,10 +55,6 @@ export const UserGroup = Object.freeze({
   Normal: 10,
   WikiEditor: 11,
 } as const);
-
-const nsfwRestrictedUIDs = new Set([
-  873244, // by @everpcpc
-]);
 
 export interface IAuth {
   userID: number;
@@ -149,15 +149,18 @@ export function emptyAuth(): IAuth {
 
 async function userToAuth(user: res.ISlimUser, appID?: string): Promise<IAuth> {
   const perms = await fetchPermission(user.group);
+  const privacy = await fetchPrivacyByUserID(user.id);
+  const showNsfwSubject = isNsfwSubjectPreferenceEnabled(privacy);
   return {
     userID: user.id,
     login: true,
     permission: perms,
-    allowNsfw:
-      !nsfwRestrictedUIDs.has(user.id) &&
-      !perms.ban_visit &&
-      !perms.user_ban &&
-      DateTime.now().toUnixInteger() - user.joinedAt >= 60 * 60 * 24 * 90,
+    allowNsfw: canViewNsfwSubject({
+      showNsfwSubject,
+      userID: user.id,
+      regTime: user.joinedAt,
+      permission: perms,
+    }),
     regTime: user.joinedAt,
     groupID: user.group,
     source: getTimelineSourceFromAppID(appID ?? '') ?? defaultSource,

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -2,10 +2,10 @@ import * as lodash from 'lodash-es';
 
 import { db, incr, op, schema, type Txn } from '@app/drizzle';
 import { siteUrl } from '@app/lib/config.ts';
+import { PrivacySettingKey, PrivacyValue, readPrivacySetting } from '@app/lib/user/privacy.ts';
 import { isFriends, parseBlocklist } from '@app/lib/user/utils.ts';
 
 import { NotFoundError, UnreachableError } from './error.ts';
-import { decode } from './utils/index.ts';
 
 /**
  * `nt_type`
@@ -68,13 +68,6 @@ export const NotifyType = Object.freeze({
 
 export type NotifyType = (typeof NotifyType)[keyof typeof NotifyType];
 
-export const PrivacyFilter = Object.freeze({
-  All: 0,
-  Friends: 1,
-  None: 2,
-});
-export type PrivacyFilter = (typeof PrivacyFilter)[keyof typeof PrivacyFilter];
-
 interface Creation {
   destUserID: number;
   sourceUserID: number;
@@ -103,29 +96,14 @@ interface Filter {
   limit: number;
 }
 
-type UserPrivacySettingsField = number;
-
-const UserPrivacyReceivePrivateMessage: UserPrivacySettingsField = 1;
-const UserPrivacyReceiveTimelineReply: UserPrivacySettingsField = 30;
-const UserPrivacyReceiveMentionNotification: UserPrivacySettingsField = 20;
-const UserPrivacyReceiveCommentNotification: UserPrivacySettingsField = 21;
-
 interface PrivacySetting {
-  TimelineReply: PrivacyFilter;
-  CommentNotification: PrivacyFilter;
-  MentionNotification: PrivacyFilter;
-  PrivateMessage: PrivacyFilter;
+  TimelineReply: PrivacyValue;
+  CommentNotification: PrivacyValue;
+  MentionNotification: PrivacyValue;
+  PrivateMessage: PrivacyValue;
 
   blockedUsers: number[];
 }
-
-const defaultPrivacySetting: PrivacySetting = {
-  TimelineReply: PrivacyFilter.All,
-  CommentNotification: PrivacyFilter.All,
-  MentionNotification: PrivacyFilter.All,
-  PrivateMessage: PrivacyFilter.All,
-  blockedUsers: [],
-};
 
 export const Notify = {
   /**
@@ -145,10 +123,10 @@ export const Notify = {
     if (setting.blockedUsers.includes(sourceUserID)) {
       return;
     }
-    if (setting.CommentNotification === PrivacyFilter.None) {
+    if (setting.CommentNotification === PrivacyValue.None) {
       return;
     }
-    if (setting.CommentNotification === PrivacyFilter.Friends) {
+    if (setting.CommentNotification === PrivacyValue.Friends) {
       const isFriend = await isFriends(destUserID, sourceUserID);
       if (!isFriend) {
         return;
@@ -270,19 +248,11 @@ async function getUserNotifySetting(userID: number): Promise<PrivacySetting> {
   }
 
   const blockedUsers = parseBlocklist(uf.blocklist);
-  if (!uf.privacy) {
-    return {
-      ...defaultPrivacySetting,
-      blockedUsers,
-    };
-  }
-
-  const field = decode(uf.privacy) as Record<number, number>;
   return {
-    PrivateMessage: field[UserPrivacyReceivePrivateMessage] as PrivacyFilter,
-    TimelineReply: field[UserPrivacyReceiveTimelineReply] as PrivacyFilter,
-    MentionNotification: field[UserPrivacyReceiveMentionNotification] as PrivacyFilter,
-    CommentNotification: field[UserPrivacyReceiveCommentNotification] as PrivacyFilter,
+    PrivateMessage: readPrivacySetting(uf.privacy, PrivacySettingKey.PrivateMessage),
+    TimelineReply: readPrivacySetting(uf.privacy, PrivacySettingKey.TimelineReply),
+    MentionNotification: readPrivacySetting(uf.privacy, PrivacySettingKey.MentionNotification),
+    CommentNotification: readPrivacySetting(uf.privacy, PrivacySettingKey.CommentNotification),
     blockedUsers,
   };
 }

--- a/lib/notify.ts
+++ b/lib/notify.ts
@@ -100,6 +100,7 @@ interface PrivacySetting {
   TimelineReply: PrivacyValue;
   CommentNotification: PrivacyValue;
   MentionNotification: PrivacyValue;
+  FriendNotification: PrivacyValue;
   PrivateMessage: PrivacyValue;
 
   blockedUsers: number[];
@@ -123,10 +124,11 @@ export const Notify = {
     if (setting.blockedUsers.includes(sourceUserID)) {
       return;
     }
-    if (setting.CommentNotification === PrivacyValue.None) {
+    const privacyValue = privacyValueForNotifyType(type, setting);
+    if (privacyValue === PrivacyValue.None) {
       return;
     }
-    if (setting.CommentNotification === PrivacyValue.Friends) {
+    if (privacyValue === PrivacyValue.Friends) {
       const isFriend = await isFriends(destUserID, sourceUserID);
       if (!isFriend) {
         return;
@@ -253,8 +255,21 @@ async function getUserNotifySetting(userID: number): Promise<PrivacySetting> {
     TimelineReply: readPrivacySetting(uf.privacy, PrivacySettingKey.TimelineReply),
     MentionNotification: readPrivacySetting(uf.privacy, PrivacySettingKey.MentionNotification),
     CommentNotification: readPrivacySetting(uf.privacy, PrivacySettingKey.CommentNotification),
+    FriendNotification: readPrivacySetting(uf.privacy, PrivacySettingKey.FriendNotification),
     blockedUsers,
   };
+}
+
+function privacyValueForNotifyType(type: NotifyType, setting: PrivacySetting): PrivacyValue {
+  if (type === NotifyType.RequestFriend || type === NotifyType.AcceptFriend) {
+    return setting.FriendNotification;
+  }
+
+  if (type >= NotifyType._23 && type <= NotifyType._34) {
+    return setting.MentionNotification;
+  }
+
+  return setting.CommentNotification;
 }
 
 /** 计算 notifyField 的 hash 字段，参照 settings */

--- a/lib/user/cache.ts
+++ b/lib/user/cache.ts
@@ -21,3 +21,7 @@ export function getRelationCacheKey(uid: number, fid: number): string {
 export function getJoinedGroupsCacheKey(uid: number): string {
   return `user:groups:${uid}`;
 }
+
+export function getPrivacyCacheKey(uid: number): string {
+  return `user:privacy:${uid}`;
+}

--- a/lib/user/privacy.test.ts
+++ b/lib/user/privacy.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  canViewNsfwSubject,
+  formatUserPrivacy,
+  patchPrivacyRaw,
+  PrivacyValue,
+  serializePrivacyRaw,
+} from './privacy.ts';
+
+describe('privacy settings', () => {
+  test('should use main site defaults', () => {
+    expect(formatUserPrivacy('').settings).toEqual({
+      privateMessage: 'all',
+      timelineReply: 'all',
+      timelineCollectReply: 'friends',
+      follow: 'all',
+      mentionNotification: 'all',
+      commentNotification: 'all',
+      friendNotification: 'all',
+    });
+  });
+
+  test('should decode known settings and preferences', () => {
+    expect(
+      formatUserPrivacy('{"1":1,"21":2,"32":0,"40":2,"show_nsfw_subject":1}', {
+        userID: 100,
+        regTime: 1_000,
+        now: 1_000 + 60 * 60 * 24 * 61,
+      }),
+    ).toEqual({
+      settings: {
+        privateMessage: 'friends',
+        timelineReply: 'all',
+        timelineCollectReply: 'all',
+        follow: 'none',
+        mentionNotification: 'all',
+        commentNotification: 'none',
+        friendNotification: 'all',
+      },
+      preferences: {
+        showNsfwSubject: true,
+        canSetNsfwSubject: true,
+        allowNsfw: true,
+      },
+    });
+  });
+
+  test('should ignore invalid known values', () => {
+    expect(formatUserPrivacy('{"1":"","40":1,"show_nsfw_subject":""}')).toMatchObject({
+      settings: {
+        privateMessage: 'all',
+        follow: 'all',
+      },
+      preferences: {
+        showNsfwSubject: false,
+      },
+    });
+  });
+
+  test('should patch requested fields and preserve unknown keys', () => {
+    const next = patchPrivacyRaw('{"32":1,"future_key":42,"show_nsfw_subject":1}', {
+      settings: {
+        privateMessage: PrivacyValue.Friends,
+        follow: PrivacyValue.None,
+      },
+      preferences: {
+        showNsfwSubject: false,
+      },
+    });
+
+    expect(next).toEqual({
+      1: 1,
+      32: 1,
+      40: 2,
+      future_key: 42,
+      show_nsfw_subject: 0,
+    });
+    expect(serializePrivacyRaw(next)).toBe(
+      '{"1":1,"32":1,"40":2,"future_key":42,"show_nsfw_subject":0}',
+    );
+  });
+
+  test('should reject setting values not allowed by main site type config', () => {
+    expect(() =>
+      patchPrivacyRaw('', {
+        settings: {
+          follow: PrivacyValue.Friends as never,
+        },
+      }),
+    ).toThrow('follow does not allow friends');
+  });
+});
+
+describe('nsfw preference gate', () => {
+  test('should require preference, age, and active permission', () => {
+    const eligibleAt = 1_000 + 60 * 60 * 24 * 60;
+
+    expect(
+      canViewNsfwSubject({
+        showNsfwSubject: true,
+        userID: 100,
+        regTime: 1_000,
+        now: eligibleAt,
+      }),
+    ).toBe(true);
+    expect(
+      canViewNsfwSubject({
+        showNsfwSubject: false,
+        userID: 100,
+        regTime: 1_000,
+        now: eligibleAt,
+      }),
+    ).toBe(false);
+    expect(
+      canViewNsfwSubject({
+        showNsfwSubject: true,
+        userID: 100,
+        regTime: 1_000,
+        now: eligibleAt - 1,
+      }),
+    ).toBe(false);
+    expect(
+      canViewNsfwSubject({
+        showNsfwSubject: true,
+        userID: 100,
+        regTime: 1_000,
+        permission: { ban_visit: true },
+        now: eligibleAt,
+      }),
+    ).toBe(false);
+  });
+
+  test('should treat restricted user id as not eligible', () => {
+    const eligibleAt = 1_000 + 60 * 60 * 24 * 60;
+
+    expect(
+      formatUserPrivacy('{"show_nsfw_subject":1}', {
+        userID: 873244,
+        regTime: 1_000,
+        now: eligibleAt,
+      }).preferences,
+    ).toEqual({
+      showNsfwSubject: true,
+      canSetNsfwSubject: false,
+      allowNsfw: false,
+    });
+  });
+});

--- a/lib/user/privacy.ts
+++ b/lib/user/privacy.ts
@@ -1,4 +1,5 @@
 import { db, op, schema } from '@app/drizzle';
+import { TypedCache } from '@app/lib/cache.ts';
 import type { Permission } from '@app/lib/user/perm.ts';
 import { decode } from '@app/lib/utils/index.ts';
 
@@ -73,6 +74,8 @@ const nsfwRestrictedUserIDs = new Set([
 
 const nsfwSubjectPreferenceKey = 'show_nsfw_subject';
 const nsfwEligibilitySeconds = 60 * 60 * 24 * 60;
+const privacyCacheTTL = 60;
+const privacyCache = TypedCache<number, string>((userID) => `user:privacy:${userID}`);
 
 const settingConfigs: Record<PrivacySettingKey, PrivacyTypeConfig> = {
   [PrivacySettingKey.PrivateMessage]: {
@@ -135,13 +138,24 @@ const privacyIDToValue: Record<number, PrivacyValue> = {
 };
 
 export async function fetchPrivacyByUserID(userID: number): Promise<string> {
+  const cached = await privacyCache.get(userID);
+  if (cached !== null) {
+    return cached;
+  }
+
   const [field] = await db
     .select({ privacy: schema.chiiUserFields.privacy })
     .from(schema.chiiUserFields)
     .where(op.eq(schema.chiiUserFields.uid, userID))
     .limit(1);
 
-  return field?.privacy ?? '';
+  const privacy = field?.privacy ?? '';
+  await privacyCache.set(userID, privacy, privacyCacheTTL);
+  return privacy;
+}
+
+export async function clearCachedPrivacyByUserID(userID: number): Promise<void> {
+  await privacyCache.del(userID);
 }
 
 export function parsePrivacyRaw(privacy: string): PrivacyRaw {

--- a/lib/user/privacy.ts
+++ b/lib/user/privacy.ts
@@ -1,5 +1,6 @@
 import { db, op, schema } from '@app/drizzle';
-import { TypedCache } from '@app/lib/cache.ts';
+import redis from '@app/lib/redis.ts';
+import { getPrivacyCacheKey } from '@app/lib/user/cache.ts';
 import type { Permission } from '@app/lib/user/perm.ts';
 import { decode } from '@app/lib/utils/index.ts';
 
@@ -75,7 +76,6 @@ const nsfwRestrictedUserIDs = new Set([
 const nsfwSubjectPreferenceKey = 'show_nsfw_subject';
 const nsfwEligibilitySeconds = 60 * 60 * 24 * 60;
 const privacyCacheTTL = 60;
-const privacyCache = TypedCache<number, string>((userID) => `user:privacy:${userID}`);
 
 const settingConfigs: Record<PrivacySettingKey, PrivacyTypeConfig> = {
   [PrivacySettingKey.PrivateMessage]: {
@@ -138,7 +138,8 @@ const privacyIDToValue: Record<number, PrivacyValue> = {
 };
 
 export async function fetchPrivacyByUserID(userID: number): Promise<string> {
-  const cached = await privacyCache.get(userID);
+  const key = getPrivacyCacheKey(userID);
+  const cached = await redis.get(key);
   if (cached !== null) {
     return cached;
   }
@@ -150,12 +151,8 @@ export async function fetchPrivacyByUserID(userID: number): Promise<string> {
     .limit(1);
 
   const privacy = field?.privacy ?? '';
-  await privacyCache.set(userID, privacy, privacyCacheTTL);
+  await redis.setex(key, privacyCacheTTL, privacy);
   return privacy;
-}
-
-export async function clearCachedPrivacyByUserID(userID: number): Promise<void> {
-  await privacyCache.del(userID);
 }
 
 export function parsePrivacyRaw(privacy: string): PrivacyRaw {

--- a/lib/user/privacy.ts
+++ b/lib/user/privacy.ts
@@ -1,0 +1,338 @@
+import { db, op, schema } from '@app/drizzle';
+import type { Permission } from '@app/lib/user/perm.ts';
+import { decode } from '@app/lib/utils/index.ts';
+
+export const PrivacyValue = Object.freeze({
+  All: 'all',
+  Friends: 'friends',
+  None: 'none',
+} as const);
+
+export type PrivacyValue = (typeof PrivacyValue)[keyof typeof PrivacyValue];
+export type BinaryPrivacyValue = typeof PrivacyValue.All | typeof PrivacyValue.None;
+
+export const PrivacySettingKey = Object.freeze({
+  PrivateMessage: 'privateMessage',
+  MentionNotification: 'mentionNotification',
+  CommentNotification: 'commentNotification',
+  FriendNotification: 'friendNotification',
+  TimelineReply: 'timelineReply',
+  TimelineCollectReply: 'timelineCollectReply',
+  Follow: 'follow',
+} as const);
+
+export type PrivacySettingKey = (typeof PrivacySettingKey)[keyof typeof PrivacySettingKey];
+
+export interface PrivacySettings {
+  privateMessage: PrivacyValue;
+  mentionNotification: PrivacyValue;
+  commentNotification: PrivacyValue;
+  friendNotification: BinaryPrivacyValue;
+  timelineReply: PrivacyValue;
+  timelineCollectReply: PrivacyValue;
+  follow: BinaryPrivacyValue;
+}
+
+export interface PrivacyPreferences {
+  showNsfwSubject: boolean;
+  canSetNsfwSubject: boolean;
+  allowNsfw: boolean;
+}
+
+export interface UserPrivacy {
+  settings: PrivacySettings;
+  preferences: PrivacyPreferences;
+}
+
+export interface PrivacyPatch {
+  settings?: Partial<{
+    privateMessage: PrivacyValue;
+    mentionNotification: PrivacyValue;
+    commentNotification: PrivacyValue;
+    friendNotification: BinaryPrivacyValue;
+    timelineReply: PrivacyValue;
+    timelineCollectReply: PrivacyValue;
+    follow: BinaryPrivacyValue;
+  }>;
+  preferences?: Partial<{
+    showNsfwSubject: boolean;
+  }>;
+}
+
+interface PrivacyTypeConfig {
+  id: number;
+  defaultValue: PrivacyValue;
+  allowedValues: readonly PrivacyValue[];
+}
+
+type PrivacyRaw = Record<string, unknown>;
+
+const nsfwRestrictedUserIDs = new Set([
+  873244, // by @everpcpc
+]);
+
+const nsfwSubjectPreferenceKey = 'show_nsfw_subject';
+const nsfwEligibilitySeconds = 60 * 60 * 24 * 60;
+
+const settingConfigs: Record<PrivacySettingKey, PrivacyTypeConfig> = {
+  [PrivacySettingKey.PrivateMessage]: {
+    id: 1,
+    defaultValue: PrivacyValue.All,
+    allowedValues: [PrivacyValue.All, PrivacyValue.Friends, PrivacyValue.None],
+  },
+  [PrivacySettingKey.MentionNotification]: {
+    id: 20,
+    defaultValue: PrivacyValue.All,
+    allowedValues: [PrivacyValue.All, PrivacyValue.Friends, PrivacyValue.None],
+  },
+  [PrivacySettingKey.CommentNotification]: {
+    id: 21,
+    defaultValue: PrivacyValue.All,
+    allowedValues: [PrivacyValue.All, PrivacyValue.Friends, PrivacyValue.None],
+  },
+  [PrivacySettingKey.FriendNotification]: {
+    id: 23,
+    defaultValue: PrivacyValue.All,
+    allowedValues: [PrivacyValue.All, PrivacyValue.None],
+  },
+  [PrivacySettingKey.TimelineReply]: {
+    id: 30,
+    defaultValue: PrivacyValue.All,
+    allowedValues: [PrivacyValue.All, PrivacyValue.Friends, PrivacyValue.None],
+  },
+  [PrivacySettingKey.TimelineCollectReply]: {
+    id: 32,
+    defaultValue: PrivacyValue.Friends,
+    allowedValues: [PrivacyValue.All, PrivacyValue.Friends, PrivacyValue.None],
+  },
+  [PrivacySettingKey.Follow]: {
+    id: 40,
+    defaultValue: PrivacyValue.All,
+    allowedValues: [PrivacyValue.All, PrivacyValue.None],
+  },
+};
+
+const settingOrder = [
+  PrivacySettingKey.PrivateMessage,
+  PrivacySettingKey.TimelineReply,
+  PrivacySettingKey.TimelineCollectReply,
+  PrivacySettingKey.Follow,
+  PrivacySettingKey.MentionNotification,
+  PrivacySettingKey.CommentNotification,
+  PrivacySettingKey.FriendNotification,
+] as const;
+
+const privacyValueToID: Record<PrivacyValue, number> = {
+  [PrivacyValue.All]: 0,
+  [PrivacyValue.Friends]: 1,
+  [PrivacyValue.None]: 2,
+};
+
+const privacyIDToValue: Record<number, PrivacyValue> = {
+  0: PrivacyValue.All,
+  1: PrivacyValue.Friends,
+  2: PrivacyValue.None,
+};
+
+export async function fetchPrivacyByUserID(userID: number): Promise<string> {
+  const [field] = await db
+    .select({ privacy: schema.chiiUserFields.privacy })
+    .from(schema.chiiUserFields)
+    .where(op.eq(schema.chiiUserFields.uid, userID))
+    .limit(1);
+
+  return field?.privacy ?? '';
+}
+
+export function parsePrivacyRaw(privacy: string): PrivacyRaw {
+  if (!privacy) {
+    return {};
+  }
+
+  try {
+    const raw = decode(privacy);
+    if (isPlainRecord(raw)) {
+      return raw;
+    }
+  } catch {
+    return {};
+  }
+
+  return {};
+}
+
+export function serializePrivacyRaw(raw: PrivacyRaw): string {
+  return JSON.stringify(raw);
+}
+
+export function formatUserPrivacy(
+  privacy: string,
+  {
+    userID = 0,
+    regTime = 0,
+    permission = {},
+    now = currentUnixSeconds(),
+  }: {
+    userID?: number;
+    regTime?: number;
+    permission?: Readonly<Permission>;
+    now?: number;
+  } = {},
+): UserPrivacy {
+  const raw = parsePrivacyRaw(privacy);
+  const showNsfwSubject = isNsfwSubjectPreferenceEnabled(raw);
+  const canSetNsfwSubject = canSetNsfwSubjectPreference({ userID, regTime, now });
+
+  return {
+    settings: readPrivacySettings(raw),
+    preferences: {
+      showNsfwSubject,
+      canSetNsfwSubject,
+      allowNsfw: canViewNsfwSubject({
+        showNsfwSubject,
+        userID,
+        regTime,
+        permission,
+        now,
+      }),
+    },
+  };
+}
+
+export function patchPrivacyRaw(privacy: string, patch: PrivacyPatch): PrivacyRaw {
+  const raw = parsePrivacyRaw(privacy);
+  const next: PrivacyRaw = { ...raw };
+
+  if (patch.settings) {
+    for (const key of settingOrder) {
+      if (!hasOwn(patch.settings, key)) {
+        continue;
+      }
+      const value = patch.settings[key];
+      if (value === undefined) {
+        continue;
+      }
+      assertAllowedPrivacyValue(key, value);
+      next[String(settingConfigs[key].id)] = privacyValueToID[value];
+    }
+  }
+
+  if (patch.preferences && hasOwn(patch.preferences, 'showNsfwSubject')) {
+    next[nsfwSubjectPreferenceKey] = patch.preferences.showNsfwSubject ? 1 : 0;
+  }
+
+  return next;
+}
+
+export function readPrivacySetting(privacy: string, key: PrivacySettingKey): PrivacyValue {
+  return readPrivacySettingFromRaw(parsePrivacyRaw(privacy), key);
+}
+
+export function isNsfwSubjectPreferenceEnabled(privacy: string | PrivacyRaw): boolean {
+  const raw = typeof privacy === 'string' ? parsePrivacyRaw(privacy) : privacy;
+  return toInteger(raw[nsfwSubjectPreferenceKey]) === 1;
+}
+
+export function canSetNsfwSubjectPreference({
+  userID,
+  regTime,
+  now = currentUnixSeconds(),
+}: {
+  userID: number;
+  regTime: number;
+  now?: number;
+}): boolean {
+  return (
+    userID > 0 &&
+    regTime > 0 &&
+    !nsfwRestrictedUserIDs.has(userID) &&
+    now >= regTime + nsfwEligibilitySeconds
+  );
+}
+
+export function canViewNsfwSubject({
+  showNsfwSubject,
+  userID,
+  regTime,
+  permission = {},
+  now = currentUnixSeconds(),
+}: {
+  showNsfwSubject: boolean;
+  userID: number;
+  regTime: number;
+  permission?: Readonly<Permission>;
+  now?: number;
+}): boolean {
+  return (
+    showNsfwSubject &&
+    canSetNsfwSubjectPreference({ userID, regTime, now }) &&
+    !nsfwRestrictedUserIDs.has(userID) &&
+    !permission.ban_visit &&
+    !permission.user_ban
+  );
+}
+
+function readPrivacySettings(raw: PrivacyRaw): PrivacySettings {
+  return {
+    privateMessage: readPrivacySettingFromRaw(raw, PrivacySettingKey.PrivateMessage),
+    timelineReply: readPrivacySettingFromRaw(raw, PrivacySettingKey.TimelineReply),
+    timelineCollectReply: readPrivacySettingFromRaw(raw, PrivacySettingKey.TimelineCollectReply),
+    follow: readPrivacySettingFromRaw(raw, PrivacySettingKey.Follow) as BinaryPrivacyValue,
+    mentionNotification: readPrivacySettingFromRaw(raw, PrivacySettingKey.MentionNotification),
+    commentNotification: readPrivacySettingFromRaw(raw, PrivacySettingKey.CommentNotification),
+    friendNotification: readPrivacySettingFromRaw(
+      raw,
+      PrivacySettingKey.FriendNotification,
+    ) as BinaryPrivacyValue,
+  };
+}
+
+function readPrivacySettingFromRaw(raw: PrivacyRaw, key: PrivacySettingKey): PrivacyValue {
+  const config = settingConfigs[key];
+  const rawValue = toInteger(raw[String(config.id)]);
+  const value = rawValue === undefined ? undefined : privacyIDToValue[rawValue];
+
+  if (value && config.allowedValues.includes(value)) {
+    return value;
+  }
+
+  return config.defaultValue;
+}
+
+function assertAllowedPrivacyValue(key: PrivacySettingKey, value: PrivacyValue): void {
+  const config = settingConfigs[key];
+  if (!config.allowedValues.includes(value)) {
+    throw new TypeError(`${key} does not allow ${value}`);
+  }
+}
+
+function toInteger(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    if (!/^-?\d+$/.test(value)) {
+      return;
+    }
+    const n = Number(value);
+    if (Number.isInteger(n)) {
+      return n;
+    }
+  }
+}
+
+function isPlainRecord(value: unknown): value is PrivacyRaw {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOwn<T extends object, K extends PropertyKey>(
+  value: T,
+  key: K,
+): value is T & Record<K, unknown> {
+  return Object.hasOwn(value, key);
+}
+
+function currentUnixSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}

--- a/lib/user/privacy.ts
+++ b/lib/user/privacy.ts
@@ -288,13 +288,10 @@ function readPrivacySettings(raw: PrivacyRaw): PrivacySettings {
     privateMessage: readPrivacySettingFromRaw(raw, PrivacySettingKey.PrivateMessage),
     timelineReply: readPrivacySettingFromRaw(raw, PrivacySettingKey.TimelineReply),
     timelineCollectReply: readPrivacySettingFromRaw(raw, PrivacySettingKey.TimelineCollectReply),
-    follow: readPrivacySettingFromRaw(raw, PrivacySettingKey.Follow) as BinaryPrivacyValue,
+    follow: readBinaryPrivacySettingFromRaw(raw, PrivacySettingKey.Follow),
     mentionNotification: readPrivacySettingFromRaw(raw, PrivacySettingKey.MentionNotification),
     commentNotification: readPrivacySettingFromRaw(raw, PrivacySettingKey.CommentNotification),
-    friendNotification: readPrivacySettingFromRaw(
-      raw,
-      PrivacySettingKey.FriendNotification,
-    ) as BinaryPrivacyValue,
+    friendNotification: readBinaryPrivacySettingFromRaw(raw, PrivacySettingKey.FriendNotification),
   };
 }
 
@@ -308,6 +305,14 @@ function readPrivacySettingFromRaw(raw: PrivacyRaw, key: PrivacySettingKey): Pri
   }
 
   return config.defaultValue;
+}
+
+function readBinaryPrivacySettingFromRaw(raw: PrivacyRaw, key: PrivacySettingKey): BinaryPrivacyValue {
+  const value = readPrivacySettingFromRaw(raw, key);
+  if (value === PrivacyValue.Friends) {
+    throw new TypeError(`${key} must be all or none, got ${value}`);
+  }
+  return value;
 }
 
 function assertAllowedPrivacyValue(key: PrivacySettingKey, value: PrivacyValue): void {

--- a/lib/user/privacy.ts
+++ b/lib/user/privacy.ts
@@ -307,7 +307,10 @@ function readPrivacySettingFromRaw(raw: PrivacyRaw, key: PrivacySettingKey): Pri
   return config.defaultValue;
 }
 
-function readBinaryPrivacySettingFromRaw(raw: PrivacyRaw, key: PrivacySettingKey): BinaryPrivacyValue {
+function readBinaryPrivacySettingFromRaw(
+  raw: PrivacyRaw,
+  key: PrivacySettingKey,
+): BinaryPrivacyValue {
   const value = readPrivacySettingFromRaw(raw, key);
   if (value === PrivacyValue.Friends) {
     throw new TypeError(`${key} must be all or none, got ${value}`);

--- a/routes/__snapshots__/index.test.ts.snap
+++ b/routes/__snapshots__/index.test.ts.snap
@@ -8327,6 +8327,267 @@ paths:
       summary: 获取人物的参与作品
       tags:
         - person
+  /p1/privacy:
+    get:
+      operationId: getPrivacy
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  preferences:
+                    properties:
+                      allowNsfw:
+                        type: boolean
+                      canSetNsfwSubject:
+                        type: boolean
+                      showNsfwSubject:
+                        type: boolean
+                    required:
+                      - showNsfwSubject
+                      - canSetNsfwSubject
+                      - allowNsfw
+                    type: object
+                  settings:
+                    properties:
+                      commentNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      follow:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      friendNotification:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      mentionNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      privateMessage:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineCollectReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                    required:
+                      - privateMessage
+                      - timelineReply
+                      - timelineCollectReply
+                      - follow
+                      - mentionNotification
+                      - commentNotification
+                      - friendNotification
+                    type: object
+                required:
+                  - settings
+                  - preferences
+                type: object
+          description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: Get current user privacy settings
+      tags:
+        - user
+    patch:
+      operationId: patchPrivacy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              properties:
+                preferences:
+                  additionalProperties: false
+                  properties:
+                    showNsfwSubject:
+                      type: boolean
+                  type: object
+                settings:
+                  additionalProperties: false
+                  properties:
+                    commentNotification:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    follow:
+                      enum:
+                        - all
+                        - none
+                      type: string
+                    friendNotification:
+                      enum:
+                        - all
+                        - none
+                      type: string
+                    mentionNotification:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    privateMessage:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    timelineCollectReply:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    timelineReply:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                  type: object
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  preferences:
+                    properties:
+                      allowNsfw:
+                        type: boolean
+                      canSetNsfwSubject:
+                        type: boolean
+                      showNsfwSubject:
+                        type: boolean
+                    required:
+                      - showNsfwSubject
+                      - canSetNsfwSubject
+                      - allowNsfw
+                    type: object
+                  settings:
+                    properties:
+                      commentNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      follow:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      friendNotification:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      mentionNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      privateMessage:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineCollectReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                    required:
+                      - privateMessage
+                      - timelineReply
+                      - timelineCollectReply
+                      - follow
+                      - mentionNotification
+                      - commentNotification
+                      - friendNotification
+                    type: object
+                required:
+                  - settings
+                  - preferences
+                type: object
+          description: Default Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: Update current user privacy settings
+      tags:
+        - user
   /p1/report:
     post:
       operationId: createReport

--- a/routes/private/index.ts
+++ b/routes/private/index.ts
@@ -19,6 +19,7 @@ import * as group from './routes/group.ts';
 import * as index from './routes/index.ts';
 import * as misc from './routes/misc.ts';
 import * as person from './routes/person.ts';
+import * as privacy from './routes/privacy.ts';
 import * as friend from './routes/relationship.ts';
 import * as report from './routes/report.ts';
 import * as search from './routes/search.ts';
@@ -86,6 +87,7 @@ async function API(app: App) {
   await app.register(index.setup);
   await app.register(misc.setup);
   await app.register(person.setup);
+  await app.register(privacy.setup);
   await app.register(report.setup);
   await app.register(search.setup);
   await app.register(subject.setup);

--- a/routes/private/routes/privacy.test.ts
+++ b/routes/private/routes/privacy.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { db, op, schema } from '@app/drizzle';
+import { emptyAuth } from '@app/lib/auth/index.ts';
+import { createTestServer } from '@app/tests/utils.ts';
+
+import { setup } from './privacy.ts';
+
+const testUserID = 900_001;
+const oldRegTime = Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 61;
+
+describe('privacy route', () => {
+  beforeEach(async () => {
+    await db.delete(schema.chiiUserFields).where(op.eq(schema.chiiUserFields.uid, testUserID));
+    await db.insert(schema.chiiUserFields).values({
+      uid: testUserID,
+      site: '',
+      location: '',
+      bio: '',
+      homepage: '',
+      privacy: '{"32":2,"future_key":42,"show_nsfw_subject":1}',
+      blocklist: '',
+    });
+  });
+
+  afterEach(async () => {
+    await db.delete(schema.chiiUserFields).where(op.eq(schema.chiiUserFields.uid, testUserID));
+  });
+
+  test('should get privacy settings', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: testUserID,
+        regTime: oldRegTime,
+      },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'get',
+      url: '/privacy',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      settings: {
+        privateMessage: 'all',
+        timelineReply: 'all',
+        timelineCollectReply: 'none',
+        follow: 'all',
+        mentionNotification: 'all',
+        commentNotification: 'all',
+        friendNotification: 'all',
+      },
+      preferences: {
+        showNsfwSubject: true,
+        canSetNsfwSubject: true,
+        allowNsfw: true,
+      },
+    });
+  });
+
+  test('should patch privacy settings and preserve unknown keys', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: testUserID,
+        regTime: oldRegTime,
+      },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'patch',
+      url: '/privacy',
+      payload: {
+        settings: {
+          privateMessage: 'friends',
+          follow: 'none',
+        },
+        preferences: {
+          showNsfwSubject: false,
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      settings: {
+        privateMessage: 'friends',
+        timelineReply: 'all',
+        timelineCollectReply: 'none',
+        follow: 'none',
+        mentionNotification: 'all',
+        commentNotification: 'all',
+        friendNotification: 'all',
+      },
+      preferences: {
+        showNsfwSubject: false,
+        canSetNsfwSubject: true,
+        allowNsfw: false,
+      },
+    });
+
+    const [field] = await db
+      .select({ privacy: schema.chiiUserFields.privacy })
+      .from(schema.chiiUserFields)
+      .where(op.eq(schema.chiiUserFields.uid, testUserID))
+      .limit(1);
+    expect(JSON.parse(field?.privacy ?? '')).toEqual({
+      1: 1,
+      32: 2,
+      40: 2,
+      future_key: 42,
+      show_nsfw_subject: 0,
+    });
+  });
+
+  test('should reject nsfw preference patch before eligibility', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: testUserID,
+        regTime: Math.floor(Date.now() / 1000),
+      },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'patch',
+      url: '/privacy',
+      payload: {
+        preferences: {
+          showNsfwSubject: true,
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+
+    const [field] = await db
+      .select({ privacy: schema.chiiUserFields.privacy })
+      .from(schema.chiiUserFields)
+      .where(op.eq(schema.chiiUserFields.uid, testUserID))
+      .limit(1);
+    expect(field?.privacy).toBe('{"32":2,"future_key":42,"show_nsfw_subject":1}');
+  });
+});

--- a/routes/private/routes/privacy.ts
+++ b/routes/private/routes/privacy.ts
@@ -1,0 +1,150 @@
+import type { Static } from 'typebox';
+import t from 'typebox';
+
+import { db, op, schema } from '@app/drizzle';
+import { NotAllowedError } from '@app/lib/auth/index.ts';
+import { UnexpectedNotFoundError } from '@app/lib/error.ts';
+import { Security, Tag } from '@app/lib/openapi/index.ts';
+import * as res from '@app/lib/types/res.ts';
+import {
+  canSetNsfwSubjectPreference,
+  formatUserPrivacy,
+  patchPrivacyRaw,
+  type PrivacyPatch,
+  serializePrivacyRaw,
+} from '@app/lib/user/privacy.ts';
+import { requireLogin } from '@app/routes/hooks/pre-handler.ts';
+import type { App } from '@app/routes/type.ts';
+
+const PrivacyValue = t.String({
+  enum: ['all', 'friends', 'none'],
+});
+
+const PrivacyValueWithoutFriends = t.String({
+  enum: ['all', 'none'],
+});
+
+const PrivacySettings = t.Object({
+  privateMessage: PrivacyValue,
+  timelineReply: PrivacyValue,
+  timelineCollectReply: PrivacyValue,
+  follow: PrivacyValueWithoutFriends,
+  mentionNotification: PrivacyValue,
+  commentNotification: PrivacyValue,
+  friendNotification: PrivacyValueWithoutFriends,
+});
+
+const PrivacyPreferences = t.Object({
+  showNsfwSubject: t.Boolean(),
+  canSetNsfwSubject: t.Boolean(),
+  allowNsfw: t.Boolean(),
+});
+
+const PrivacyResponse = t.Object({
+  settings: PrivacySettings,
+  preferences: PrivacyPreferences,
+});
+
+const PrivacyPatchSettings = t.Partial(PrivacySettings, { additionalProperties: false });
+
+const PrivacyPatchPreferences = t.Partial(
+  t.Object({
+    showNsfwSubject: t.Boolean(),
+  }),
+  { additionalProperties: false },
+);
+
+const PrivacyPatchBody = t.Object(
+  {
+    settings: t.Optional(PrivacyPatchSettings),
+    preferences: t.Optional(PrivacyPatchPreferences),
+  },
+  { additionalProperties: false },
+);
+
+type PrivacyPatchBody = Static<typeof PrivacyPatchBody>;
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function setup(app: App) {
+  app.get(
+    '/privacy',
+    {
+      schema: {
+        summary: 'Get current user privacy settings',
+        operationId: 'getPrivacy',
+        tags: [Tag.User],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        response: {
+          200: PrivacyResponse,
+          401: res.Ref(res.Error),
+        },
+      },
+      preHandler: [requireLogin('get privacy')],
+    },
+    async ({ auth }) => {
+      const privacy = await requirePrivacyField(auth.userID);
+      return formatUserPrivacy(privacy, {
+        userID: auth.userID,
+        regTime: auth.regTime,
+        permission: auth.permission,
+      });
+    },
+  );
+
+  app.patch<{ Body: PrivacyPatchBody }>(
+    '/privacy',
+    {
+      schema: {
+        summary: 'Update current user privacy settings',
+        operationId: 'patchPrivacy',
+        tags: [Tag.User],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        body: PrivacyPatchBody,
+        response: {
+          200: PrivacyResponse,
+          400: res.Ref(res.Error),
+          401: res.Ref(res.Error),
+          403: res.Ref(res.Error),
+        },
+      },
+      preHandler: [requireLogin('patch privacy')],
+    },
+    async ({ auth, body }) => {
+      const privacy = await requirePrivacyField(auth.userID);
+
+      if (
+        body.preferences &&
+        Object.hasOwn(body.preferences, 'showNsfwSubject') &&
+        !canSetNsfwSubjectPreference({ userID: auth.userID, regTime: auth.regTime })
+      ) {
+        throw new NotAllowedError('set nsfw subject preference');
+      }
+
+      const nextPrivacy = serializePrivacyRaw(patchPrivacyRaw(privacy, body as PrivacyPatch));
+      await db
+        .update(schema.chiiUserFields)
+        .set({ privacy: nextPrivacy })
+        .where(op.eq(schema.chiiUserFields.uid, auth.userID));
+
+      return formatUserPrivacy(nextPrivacy, {
+        userID: auth.userID,
+        regTime: auth.regTime,
+        permission: auth.permission,
+      });
+    },
+  );
+}
+
+async function requirePrivacyField(userID: number): Promise<string> {
+  const [field] = await db
+    .select({ privacy: schema.chiiUserFields.privacy })
+    .from(schema.chiiUserFields)
+    .where(op.eq(schema.chiiUserFields.uid, userID))
+    .limit(1);
+
+  if (!field) {
+    throw new UnexpectedNotFoundError(`user field ${userID}`);
+  }
+
+  return field.privacy;
+}

--- a/routes/private/routes/privacy.ts
+++ b/routes/private/routes/privacy.ts
@@ -120,7 +120,9 @@ export async function setup(app: App) {
         throw new NotAllowedError('set nsfw subject preference');
       }
 
-      const nextPrivacy = serializePrivacyRaw(patchPrivacyRaw(privacy, body as PrivacyPatch));
+      // TypeBox widens enum strings here; patchPrivacyRaw performs runtime validation.
+      const patch = body as PrivacyPatch;
+      const nextPrivacy = serializePrivacyRaw(patchPrivacyRaw(privacy, patch));
       await db
         .update(schema.chiiUserFields)
         .set({ privacy: nextPrivacy })

--- a/routes/private/routes/relationship.test.ts
+++ b/routes/private/routes/relationship.test.ts
@@ -47,11 +47,25 @@ describe('friends', () => {
   beforeEach(async () => {
     await redis.flushdb();
     await db.delete(schema.chiiFriends).where(op.eq(schema.chiiFriends.uid, 1));
+    await db
+      .delete(schema.chiiNotify)
+      .where(op.and(op.eq(schema.chiiNotify.uid, 287622), op.eq(schema.chiiNotify.fromUID, 1)));
+    await db
+      .update(schema.chiiUserFields)
+      .set({ privacy: '' })
+      .where(op.inArray(schema.chiiUserFields.uid, [1, 287622]));
   });
 
   afterEach(async () => {
     await redis.flushdb();
     await db.delete(schema.chiiFriends).where(op.eq(schema.chiiFriends.uid, 1));
+    await db
+      .delete(schema.chiiNotify)
+      .where(op.and(op.eq(schema.chiiNotify.uid, 287622), op.eq(schema.chiiNotify.fromUID, 1)));
+    await db
+      .update(schema.chiiUserFields)
+      .set({ privacy: '' })
+      .where(op.inArray(schema.chiiUserFields.uid, [1, 287622]));
   });
 
   test('should add friend and remove friend', async () => {
@@ -89,6 +103,68 @@ describe('friends', () => {
       .from(schema.chiiFriends)
       .where(op.and(op.eq(schema.chiiFriends.uid, 1), op.eq(schema.chiiFriends.fid, 287622)));
     expect(friend2).toBeUndefined();
+  });
+
+  test('should reject adding friend when follow privacy disallows it', async () => {
+    await db
+      .update(schema.chiiUserFields)
+      .set({ privacy: '{"40":2}' })
+      .where(op.eq(schema.chiiUserFields.uid, 287622));
+
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: 1,
+      },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'put',
+      url: '/friends/287622',
+    });
+    expect(res.statusCode).toBe(403);
+
+    const [friend] = await db
+      .select()
+      .from(schema.chiiFriends)
+      .where(op.and(op.eq(schema.chiiFriends.uid, 1), op.eq(schema.chiiFriends.fid, 287622)));
+    expect(friend).toBeUndefined();
+  });
+
+  test('should not create friend notification when disabled', async () => {
+    await db
+      .update(schema.chiiUserFields)
+      .set({ privacy: '{"23":2}' })
+      .where(op.eq(schema.chiiUserFields.uid, 287622));
+
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: 1,
+      },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'put',
+      url: '/friends/287622',
+    });
+    expect(res.statusCode).toBe(200);
+
+    const [friend] = await db
+      .select()
+      .from(schema.chiiFriends)
+      .where(op.and(op.eq(schema.chiiFriends.uid, 1), op.eq(schema.chiiFriends.fid, 287622)));
+    expect(friend).toBeDefined();
+
+    const notifications = await db
+      .select()
+      .from(schema.chiiNotify)
+      .where(op.and(op.eq(schema.chiiNotify.uid, 287622), op.eq(schema.chiiNotify.fromUID, 1)));
+    expect(notifications).toEqual([]);
   });
 });
 

--- a/routes/private/routes/relationship.ts
+++ b/routes/private/routes/relationship.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 import t from 'typebox';
 
 import { db, op, schema } from '@app/drizzle';
+import { NotAllowedError } from '@app/lib/auth/index.ts';
 import { NotFoundError, UnexpectedNotFoundError } from '@app/lib/error';
 import { Notify, NotifyType } from '@app/lib/notify.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
@@ -10,6 +11,12 @@ import { AsyncTimelineWriter } from '@app/lib/timeline/writer';
 import * as convert from '@app/lib/types/convert.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
 import * as res from '@app/lib/types/res.ts';
+import {
+  fetchPrivacyByUserID,
+  PrivacySettingKey,
+  PrivacyValue,
+  readPrivacySetting,
+} from '@app/lib/user/privacy.ts';
 import { fetchFriends, parseBlocklist } from '@app/lib/user/utils.ts';
 import { LimitAction } from '@app/lib/utils/rate-limit/index.ts';
 import { requireLogin } from '@app/routes/hooks/pre-handler.ts';
@@ -91,6 +98,7 @@ export async function setup(app: App) {
       if (!user) {
         throw new NotFoundError(`user ${username}`);
       }
+      await requireFollowAllowed(auth.userID, user.id);
       await rateLimit(LimitAction.Relationship, auth.userID);
       const createdAt = DateTime.now().toUnixInteger();
       await db.transaction(async (t) => {
@@ -402,4 +410,19 @@ export async function setup(app: App) {
       return { blocklist: blocklist };
     },
   );
+}
+
+async function requireFollowAllowed(sourceUserID: number, targetUserID: number): Promise<void> {
+  const [sourcePrivacy, targetPrivacy] = await Promise.all([
+    fetchPrivacyByUserID(sourceUserID),
+    fetchPrivacyByUserID(targetUserID),
+  ]);
+
+  if (readPrivacySetting(sourcePrivacy, PrivacySettingKey.Follow) !== PrivacyValue.All) {
+    throw new NotAllowedError('add friend');
+  }
+
+  if (readPrivacySetting(targetPrivacy, PrivacySettingKey.Follow) !== PrivacyValue.All) {
+    throw new NotAllowedError('add friend');
+  }
 }

--- a/tests/event/notify.spec.ts
+++ b/tests/event/notify.spec.ts
@@ -1,13 +1,15 @@
 import { create, toBinary } from '@bufbuild/protobuf';
-import { afterEach, beforeEach, test } from 'vitest';
+import { afterEach, beforeEach, expect, test } from 'vitest';
 
 import { db, op, schema } from '@app/drizzle';
 import { handle } from '@app/event/notify.ts';
+import { Notify, NotifyType } from '@app/lib/notify.ts';
 import { NotifySchema } from '@app/vendor/proto/mq/v1/notify_pb.ts';
 
 const testDestUserID = 900_002;
 const testFromUserID = 287622;
 const testMid = 1;
+const testMids = [1, 2, 3, 4, 5];
 
 beforeEach(async () => {
   await db.delete(schema.chiiUserFields).where(op.eq(schema.chiiUserFields.uid, testDestUserID));
@@ -24,7 +26,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await db.delete(schema.chiiNotify).where(op.eq(schema.chiiNotify.uid, testDestUserID));
-  await db.delete(schema.chiiNotifyField).where(op.eq(schema.chiiNotifyField.rid, testMid));
+  await db.delete(schema.chiiNotifyField).where(op.inArray(schema.chiiNotifyField.rid, testMids));
   await db.delete(schema.chiiUserFields).where(op.eq(schema.chiiUserFields.uid, testDestUserID));
 });
 
@@ -46,3 +48,75 @@ test('should handle event notify event', async () => {
     ),
   });
 });
+
+test('should use mention notification privacy for mention notify types', async () => {
+  await db
+    .update(schema.chiiUserFields)
+    .set({ privacy: '{"20":2,"21":0}' })
+    .where(op.eq(schema.chiiUserFields.uid, testDestUserID));
+
+  await db.transaction(async (t) => {
+    await Notify.create(t, {
+      destUserID: testDestUserID,
+      sourceUserID: testFromUserID,
+      createdAt: 1,
+      type: NotifyType._23,
+      relatedID: 2,
+      mainID: 2,
+      title: 'mention',
+    });
+  });
+
+  await expect(fetchNotifyTypes()).resolves.toEqual([]);
+});
+
+test('should keep timeline status reply notify under comment notification privacy', async () => {
+  await db
+    .update(schema.chiiUserFields)
+    .set({ privacy: '{"21":0,"30":2}' })
+    .where(op.eq(schema.chiiUserFields.uid, testDestUserID));
+
+  await db.transaction(async (t) => {
+    await Notify.create(t, {
+      destUserID: testDestUserID,
+      sourceUserID: testFromUserID,
+      createdAt: 1,
+      type: NotifyType._22,
+      relatedID: 3,
+      mainID: 3,
+      title: 'timeline reply',
+    });
+  });
+
+  await expect(fetchNotifyTypes()).resolves.toEqual([NotifyType._22]);
+});
+
+test('should use friend notification privacy for friend notify types', async () => {
+  await db
+    .update(schema.chiiUserFields)
+    .set({ privacy: '{"21":0,"23":2}' })
+    .where(op.eq(schema.chiiUserFields.uid, testDestUserID));
+
+  await db.transaction(async (t) => {
+    await Notify.create(t, {
+      destUserID: testDestUserID,
+      sourceUserID: testFromUserID,
+      createdAt: 1,
+      type: NotifyType.RequestFriend,
+      relatedID: 4,
+      mainID: 4,
+      title: 'friend',
+    });
+  });
+
+  await expect(fetchNotifyTypes()).resolves.toEqual([]);
+});
+
+async function fetchNotifyTypes(): Promise<number[]> {
+  const rows = await db
+    .select({ type: schema.chiiNotify.type })
+    .from(schema.chiiNotify)
+    .where(op.eq(schema.chiiNotify.uid, testDestUserID))
+    .orderBy(schema.chiiNotify.id);
+  return rows.map((row) => row.type);
+}

--- a/tests/event/notify.spec.ts
+++ b/tests/event/notify.spec.ts
@@ -5,7 +5,7 @@ import { db, op, schema } from '@app/drizzle';
 import { handle } from '@app/event/notify.ts';
 import { NotifySchema } from '@app/vendor/proto/mq/v1/notify_pb.ts';
 
-const testDestUserID = 382951;
+const testDestUserID = 900_002;
 const testFromUserID = 287622;
 const testMid = 1;
 

--- a/tests/event/user.spec.ts
+++ b/tests/event/user.spec.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, expect, test } from 'vitest';
+
+import { db, op, schema } from '@app/drizzle';
+import { handleFields } from '@app/event/user.ts';
+import { clearCachedPrivacyByUserID, fetchPrivacyByUserID } from '@app/lib/user/privacy.ts';
+
+const testUserID = 900_003;
+
+beforeEach(async () => {
+  await clearCachedPrivacyByUserID(testUserID);
+  await db.delete(schema.chiiUserFields).where(op.eq(schema.chiiUserFields.uid, testUserID));
+  await db.insert(schema.chiiUserFields).values({
+    uid: testUserID,
+    site: '',
+    location: '',
+    bio: '',
+    homepage: '',
+    privacy: '',
+    blocklist: '',
+  });
+});
+
+afterEach(async () => {
+  await clearCachedPrivacyByUserID(testUserID);
+  await db.delete(schema.chiiUserFields).where(op.eq(schema.chiiUserFields.uid, testUserID));
+});
+
+test('should invalidate user privacy cache from memberfields event', async () => {
+  await expect(fetchPrivacyByUserID(testUserID)).resolves.toBe('');
+
+  await db
+    .update(schema.chiiUserFields)
+    .set({ privacy: '{"show_nsfw_subject":1}' })
+    .where(op.eq(schema.chiiUserFields.uid, testUserID));
+
+  await expect(fetchPrivacyByUserID(testUserID)).resolves.toBe('');
+
+  await handleFields({
+    topic: 'debezium.chii.bangumi.chii_memberfields',
+    key: JSON.stringify({ uid: testUserID }),
+    value: Buffer.from(JSON.stringify({ op: 'u' })),
+  });
+
+  await expect(fetchPrivacyByUserID(testUserID)).resolves.toBe('{"show_nsfw_subject":1}');
+});

--- a/tests/event/user.spec.ts
+++ b/tests/event/user.spec.ts
@@ -2,12 +2,14 @@ import { afterEach, beforeEach, expect, test } from 'vitest';
 
 import { db, op, schema } from '@app/drizzle';
 import { handleFields } from '@app/event/user.ts';
-import { clearCachedPrivacyByUserID, fetchPrivacyByUserID } from '@app/lib/user/privacy.ts';
+import redis from '@app/lib/redis.ts';
+import { getPrivacyCacheKey } from '@app/lib/user/cache.ts';
+import { fetchPrivacyByUserID } from '@app/lib/user/privacy.ts';
 
 const testUserID = 900_003;
 
 beforeEach(async () => {
-  await clearCachedPrivacyByUserID(testUserID);
+  await redis.del(getPrivacyCacheKey(testUserID));
   await db.delete(schema.chiiUserFields).where(op.eq(schema.chiiUserFields.uid, testUserID));
   await db.insert(schema.chiiUserFields).values({
     uid: testUserID,
@@ -21,7 +23,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await clearCachedPrivacyByUserID(testUserID);
+  await redis.del(getPrivacyCacheKey(testUserID));
   await db.delete(schema.chiiUserFields).where(op.eq(schema.chiiUserFields.uid, testUserID));
 });
 

--- a/tests/graphql/subject.test.ts
+++ b/tests/graphql/subject.test.ts
@@ -4,7 +4,11 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { db, op, schema } from '@app/drizzle';
 import { createServer } from '@app/lib/server.ts';
-import { patchPrivacyRaw, serializePrivacyRaw } from '@app/lib/user/privacy.ts';
+import {
+  clearCachedPrivacyByUserID,
+  patchPrivacyRaw,
+  serializePrivacyRaw,
+} from '@app/lib/user/privacy.ts';
 
 const testClient = createMercuriusTestClient(await createServer(), { url: '/v0/graphql' });
 const authUserID = 382951;
@@ -25,6 +29,7 @@ beforeAll(async () => {
       ),
     })
     .where(op.eq(schema.chiiUserFields.uid, authUserID));
+  await clearCachedPrivacyByUserID(authUserID);
 });
 
 afterAll(async () => {
@@ -32,6 +37,7 @@ afterAll(async () => {
     .update(schema.chiiUserFields)
     .set({ privacy: originalPrivacy })
     .where(op.eq(schema.chiiUserFields.uid, authUserID));
+  await clearCachedPrivacyByUserID(authUserID);
 });
 
 describe('subject', () => {

--- a/tests/graphql/subject.test.ts
+++ b/tests/graphql/subject.test.ts
@@ -3,12 +3,10 @@ import { createMercuriusTestClient } from 'mercurius-integration-testing';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { db, op, schema } from '@app/drizzle';
+import redis from '@app/lib/redis.ts';
 import { createServer } from '@app/lib/server.ts';
-import {
-  clearCachedPrivacyByUserID,
-  patchPrivacyRaw,
-  serializePrivacyRaw,
-} from '@app/lib/user/privacy.ts';
+import { getPrivacyCacheKey } from '@app/lib/user/cache.ts';
+import { patchPrivacyRaw, serializePrivacyRaw } from '@app/lib/user/privacy.ts';
 
 const testClient = createMercuriusTestClient(await createServer(), { url: '/v0/graphql' });
 const authUserID = 382951;
@@ -29,7 +27,7 @@ beforeAll(async () => {
       ),
     })
     .where(op.eq(schema.chiiUserFields.uid, authUserID));
-  await clearCachedPrivacyByUserID(authUserID);
+  await redis.del(getPrivacyCacheKey(authUserID));
 });
 
 afterAll(async () => {
@@ -37,7 +35,7 @@ afterAll(async () => {
     .update(schema.chiiUserFields)
     .set({ privacy: originalPrivacy })
     .where(op.eq(schema.chiiUserFields.uid, authUserID));
-  await clearCachedPrivacyByUserID(authUserID);
+  await redis.del(getPrivacyCacheKey(authUserID));
 });
 
 describe('subject', () => {

--- a/tests/graphql/subject.test.ts
+++ b/tests/graphql/subject.test.ts
@@ -1,10 +1,38 @@
 import { gql } from 'graphql-tag';
 import { createMercuriusTestClient } from 'mercurius-integration-testing';
-import { describe, expect, test } from 'vitest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
+import { db, op, schema } from '@app/drizzle';
 import { createServer } from '@app/lib/server.ts';
+import { patchPrivacyRaw, serializePrivacyRaw } from '@app/lib/user/privacy.ts';
 
 const testClient = createMercuriusTestClient(await createServer(), { url: '/v0/graphql' });
+const authUserID = 382951;
+let originalPrivacy = '';
+
+beforeAll(async () => {
+  const [field] = await db
+    .select({ privacy: schema.chiiUserFields.privacy })
+    .from(schema.chiiUserFields)
+    .where(op.eq(schema.chiiUserFields.uid, authUserID))
+    .limit(1);
+  originalPrivacy = field?.privacy ?? '';
+  await db
+    .update(schema.chiiUserFields)
+    .set({
+      privacy: serializePrivacyRaw(
+        patchPrivacyRaw(originalPrivacy, { preferences: { showNsfwSubject: true } }),
+      ),
+    })
+    .where(op.eq(schema.chiiUserFields.uid, authUserID));
+});
+
+afterAll(async () => {
+  await db
+    .update(schema.chiiUserFields)
+    .set({ privacy: originalPrivacy })
+    .where(op.eq(schema.chiiUserFields.uid, authUserID));
+});
 
 describe('subject', () => {
   test('should get', async () => {


### PR DESCRIPTION
## Problem

The private API did not expose the main-site privacy settings model. Existing code also decoded `chii_memberfields.privacy` in separate places, so notification filtering and NSFW authorization could drift from the main-site behavior.

## Approach

Add `/p1/privacy` as the API boundary for `chii_memberfields.privacy`, with partial updates that preserve unknown JSON keys and keep the legacy numeric storage format. Centralize privacy defaults, validation, NSFW preference handling, and auth/notify reads in `lib/user/privacy.ts`.

Privacy reads used by auth are cached briefly, with invalidation handled from the `chii_memberfields` Kafka/Debezium consumer path rather than write-side route logic.

## Scope

- Add `GET /p1/privacy` and `PATCH /p1/privacy`
- Keep `/p1/blocklist` unchanged because it maps to `chii_memberfields.blocklist`
- Reuse the privacy helper from auth and notify code
- Add `chii_memberfields` cache invalidation in the MQ consumer
- Update OpenAPI snapshots and tests

## Testing

- [x] `pnpm test`
- [x] `pnpm tsc`
- [x] `pnpm lint`
