### PR TITLE
fix(dam): flag bidirectional isolate controls (U+2066-U+2069) and U+061C

### DIFF
--- a/lib/dam.test.ts
+++ b/lib/dam.test.ts
@@ -7,6 +7,10 @@ test('should check printable characters', () => {
   expect(Dam.allCharacterPrintable('\u202D')).toBe(false);
   expect(Dam.allCharacterPrintable("See what's hidden in your string…\tor be​hind﻿")).toBe(false);
 
+  // bidirectional isolate controls (Unicode Bidi_Control, used in Trojan-Source attacks)
+  expect(Dam.allCharacterPrintable('\u2066')).toBe(false);
+  expect(Dam.allCharacterPrintable('\u2069')).toBe(false);
+  expect(Dam.allCharacterPrintable('\u061C')).toBe(false);
   // emoji dog face
   expect(Dam.allCharacterPrintable('\u{0001F436}')).toBe(true);
 });

--- a/lib/dam.ts
+++ b/lib/dam.ts
@@ -1,7 +1,7 @@
 /** 敏感词过滤 */
 import config from './config.ts';
 
-const controlPattern = /[\u200B-\u200F\u202A-\u202E\uFEFF]/;
+const controlPattern = /[\u061C\u200B-\u200F\u202A-\u202E\u2066-\u2069\uFEFF]/;
 
 interface Option {
   nsfw_word?: string;


### PR DESCRIPTION
`Dam.allCharacterPrintable` rejects invisible bidirectional formatting characters, but `controlPattern` only covered part of the Bidi_Control set:

```ts
const controlPattern = /[\u200B-\u200F\u202A-\u202E\uFEFF]/;
```

It matched the marks U+200E/U+200F and the embedding/override block U+202A-U+202E, but missed the directional isolate controls U+2066 (LRI), U+2067 (RLI), U+2068 (FSI), U+2069 (PDI) and U+061C (ALM). All of these belong to the Unicode Bidi_Control property (UAX #9) and produce the same visual reordering used in the Trojan-Source attack (CVE-2021-42574), so a string made only of isolates currently passes `allCharacterPrintable`.

This completes the Bidi_Control coverage:

```ts
const controlPattern = /[\u061C\u200B-\u200F\u202A-\u202E\u2066-\u2069\uFEFF]/;
```

Added assertions in `dam.test.ts` for U+2066, U+2069 and U+061C.
