### PR TITLE
ci: set renovate minimumReleaseAge to 3 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
   "rebaseWhen": "conflicted",
   "labels": ["ci:auto-merge", "dependencies"],
   "postUpdateOptions": ["pnpmDedupe"],
+  "minimumReleaseAge": "3 days",
   "rangeStrategy": "pin",
   "dockerfile": {
     "managerFilePatterns": ["Dockerfile"],


### PR DESCRIPTION
与 pnpm 默认值（3 天）对齐，避免刚发布的包版本立即被 Renovate 更新而导致不稳定。