### PR TITLE
chore: tune user action rate limits

### DIFF
--- a/lib/comment.ts
+++ b/lib/comment.ts
@@ -267,6 +267,7 @@ export class CommentWithState {
     if (reply) {
       throw new NotAllowedError('edit a comment with replies');
     }
+    await rateLimit(LimitAction.Comment, auth.userID);
     await db.update(this.table).set({ content }).where(op.eq(this.table.id, commentID));
     return {};
   }
@@ -286,6 +287,7 @@ export class CommentWithState {
     if (comment.state !== CommentState.Normal) {
       throw new NotAllowedError('delete a abnormal state comment');
     }
+    await rateLimit(LimitAction.Comment, auth.userID);
     await db
       .update(this.table)
       .set({ state: CommentState.UserDelete })
@@ -431,6 +433,7 @@ export class CommentWithoutState {
     if (reply) {
       throw new NotAllowedError('edit a comment with replies');
     }
+    await rateLimit(LimitAction.Comment, auth.userID);
     await db.update(this.table).set({ content }).where(op.eq(this.table.id, commentID));
     return {};
   }
@@ -447,6 +450,7 @@ export class CommentWithoutState {
     if (comment.uid !== auth.userID) {
       throw new NotAllowedError('delete a comment which is not yours');
     }
+    await rateLimit(LimitAction.Comment, auth.userID);
     await db.delete(this.table).where(op.eq(this.table.id, commentID)).limit(1);
     return {};
   }

--- a/lib/like.test.ts
+++ b/lib/like.test.ts
@@ -1,7 +1,54 @@
-import { expect, test } from 'vitest';
+import { afterEach, beforeEach, expect, test } from 'vitest';
 
+import { db, op, schema } from '@app/drizzle';
 import { LikeType, Reaction } from '@app/lib/like.ts';
+
+const testReaction = {
+  type: LikeType.GroupReply,
+  mid: 987001,
+  rid: 987002,
+  uid: 987003,
+  value: 54,
+};
+
+async function deleteTestReaction() {
+  await db
+    .delete(schema.chiiLikes)
+    .where(
+      op.and(
+        op.eq(schema.chiiLikes.type, testReaction.type),
+        op.eq(schema.chiiLikes.relatedID, testReaction.rid),
+        op.eq(schema.chiiLikes.uid, testReaction.uid),
+      ),
+    );
+}
+
+beforeEach(deleteTestReaction);
+afterEach(deleteTestReaction);
 
 test('group topic reactions', async () => {
   await expect(Reaction.fetchByMainID(379821, LikeType.GroupReply)).resolves.toMatchSnapshot();
+});
+
+test('delete reaction', async () => {
+  await Reaction.add(testReaction);
+  await Reaction.delete({
+    type: testReaction.type,
+    rid: testReaction.rid,
+    uid: testReaction.uid,
+  });
+
+  const [reaction] = await db
+    .select()
+    .from(schema.chiiLikes)
+    .where(
+      op.and(
+        op.eq(schema.chiiLikes.type, testReaction.type),
+        op.eq(schema.chiiLikes.relatedID, testReaction.rid),
+        op.eq(schema.chiiLikes.uid, testReaction.uid),
+      ),
+    )
+    .limit(1);
+
+  expect(reaction?.deleted).toBe(true);
 });

--- a/lib/like.ts
+++ b/lib/like.ts
@@ -226,6 +226,7 @@ export const Reaction = {
   },
 
   async delete(reaction: DeleteReaction) {
+    await rateLimit(LimitAction.Like, reaction.uid);
     await db.transaction(async (t) => {
       const [previous] = await t
         .select()

--- a/lib/utils/rate-limit/index.ts
+++ b/lib/utils/rate-limit/index.ts
@@ -40,6 +40,13 @@ export const LimitAction = Object.freeze({
   Index: { action: 'index', limit: 10, durationMinutes: 5 },
 
   /**
+   * 创建/更新用户自己的目录内容
+   *
+   * 5 分钟 15 次
+   */
+  IndexEdit: { action: 'index-edit', limit: 15, durationMinutes: 5 },
+
+  /**
    * 更新章节进度
    *
    * 5 分钟 10 次
@@ -94,6 +101,20 @@ export const LimitAction = Object.freeze({
    * 5 分钟 10 次
    */
   Relationship: { action: 'relationship', limit: 10, durationMinutes: 5 },
+
+  /**
+   * 更新用户自己的设置或轻量状态
+   *
+   * 5 分钟 10 次
+   */
+  User: { action: 'user', limit: 10, durationMinutes: 5 },
+
+  /**
+   * 创建或更新 Wiki 内容
+   *
+   * 5 分钟 10 次
+   */
+  Wiki: { action: 'wiki', limit: 10, durationMinutes: 5 },
 } as const satisfies Record<string, LimitRule>);
 
 export interface Result {

--- a/lib/utils/rate-limit/index.ts
+++ b/lib/utils/rate-limit/index.ts
@@ -14,44 +14,44 @@ export const LimitAction = Object.freeze({
   /**
    * 修改/添加条目收藏
    *
-   * 1 分钟 3 次
+   * 5 分钟 15 次
    */
-  Subject: { action: 'subject', limit: 3, durationMinutes: 1 },
+  Subject: { action: 'subject', limit: 15, durationMinutes: 5 },
 
   /**
    * 修改/添加角色收藏
    *
-   * 1 分钟 3 次
+   * 5 分钟 15 次
    */
-  Character: { action: 'character', limit: 3, durationMinutes: 1 },
+  Character: { action: 'character', limit: 15, durationMinutes: 5 },
 
   /**
    * 修改/添加人物收藏
    *
-   * 1 分钟 3 次
+   * 5 分钟 15 次
    */
-  Person: { action: 'person', limit: 3, durationMinutes: 1 },
+  Person: { action: 'person', limit: 15, durationMinutes: 5 },
 
   /**
    * 修改/添加目录收藏
    *
-   * 1 分钟 3 次
+   * 5 分钟 10 次
    */
-  Index: { action: 'index', limit: 3, durationMinutes: 1 },
+  Index: { action: 'index', limit: 10, durationMinutes: 5 },
 
   /**
    * 更新章节进度
    *
-   * 10 分钟 10 次
+   * 5 分钟 10 次
    */
-  Episode: { action: 'episode', limit: 10, durationMinutes: 10 },
+  Episode: { action: 'episode', limit: 10, durationMinutes: 5 },
 
   /**
    * 发送时间线吐槽
    *
-   * 1 分钟 3 次
+   * 5 分钟 5 次
    */
-  Timeline: { action: 'timeline', limit: 3, durationMinutes: 1 },
+  Timeline: { action: 'timeline', limit: 5, durationMinutes: 5 },
 
   /**
    * 点赞
@@ -63,37 +63,37 @@ export const LimitAction = Object.freeze({
   /**
    * 报告疑虑
    *
-   * 1 分钟 3 次
+   * 5 分钟 5 次
    */
-  Report: { action: 'report', limit: 3, durationMinutes: 1 },
+  Report: { action: 'report', limit: 5, durationMinutes: 5 },
 
   /**
    * 发表 章节/角色/人物/目录/日志/时间线 吐槽
    *
-   * 1 分钟 3 次
+   * 5 分钟 15 次
    */
-  Comment: { action: 'comment', limit: 3, durationMinutes: 1 },
+  Comment: { action: 'comment', limit: 15, durationMinutes: 5 },
 
   /**
    * 创建小组话题和条目讨论
    *
-   * 10 分钟 5 次
+   * 10 分钟 2 次
    */
-  Topic: { action: 'topic', limit: 5, durationMinutes: 10 },
+  Topic: { action: 'topic', limit: 2, durationMinutes: 10 },
 
   /**
    * 回复小组话题和条目讨论
    *
-   * 1 分钟 5 次
+   * 5 分钟 15 次
    */
-  Reply: { action: 'reply', limit: 5, durationMinutes: 1 },
+  Reply: { action: 'reply', limit: 15, durationMinutes: 5 },
 
   /**
    * 添加/删除 好友/黑名单
    *
-   * 1 分钟 3 次
+   * 5 分钟 10 次
    */
-  Relationship: { action: 'relationship', limit: 3, durationMinutes: 1 },
+  Relationship: { action: 'relationship', limit: 10, durationMinutes: 5 },
 } as const satisfies Record<string, LimitRule>);
 
 export interface Result {

--- a/routes/admin/index.test.ts
+++ b/routes/admin/index.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { db, op, schema } from '@app/drizzle';
+import { emptyAuth, UserGroup } from '@app/lib/auth/index.ts';
+import * as image from '@app/lib/image/index.ts';
+import * as Subject from '@app/lib/subject/index.ts';
+import { createTestServer } from '@app/tests/utils.ts';
+
+import { setup } from './index.ts';
+
+const testImageID = 910001;
+const testSubjectID = 990001;
+const testUserID = 987005;
+
+const deleteSubjectImageMock = vi
+  .spyOn(image, 'deleteSubjectImage')
+  .mockImplementation(() => Promise.resolve());
+const onSubjectVoteMock = vi.spyOn(Subject, 'onSubjectVote').mockImplementation(() => {
+  return Promise.resolve();
+});
+
+async function deleteTestImage() {
+  await db.delete(schema.chiiSubjectImgs).where(op.eq(schema.chiiSubjectImgs.imgId, testImageID));
+}
+
+describe('admin covers', () => {
+  beforeEach(async () => {
+    await deleteTestImage();
+    deleteSubjectImageMock.mockClear();
+    onSubjectVoteMock.mockClear();
+    await db.insert(schema.chiiSubjectImgs).values({
+      imgId: testImageID,
+      imgBan: 0,
+      imgTarget: 'testing admin target',
+      imgSubjectId: testSubjectID,
+      imgUid: testUserID,
+      imgVote: 0,
+      imgNsfw: false,
+      imgDateline: Math.floor(Date.now() / 1000),
+    });
+  });
+
+  afterEach(deleteTestImage);
+
+  test('should delete subject cover', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        groupID: UserGroup.BangumiAdmin,
+        userID: testUserID,
+        permission: { subject_cover_erase: true },
+      },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'delete',
+      url: `/subject/${testSubjectID}/covers`,
+      body: {
+        imageID: testImageID,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(deleteSubjectImageMock).toHaveBeenCalledWith('testing admin target');
+    expect(onSubjectVoteMock).toHaveBeenCalledWith(testSubjectID);
+
+    const [imageRow] = await db
+      .select()
+      .from(schema.chiiSubjectImgs)
+      .where(op.eq(schema.chiiSubjectImgs.imgId, testImageID))
+      .limit(1);
+    expect(imageRow?.imgBan).toBe(1);
+  });
+});

--- a/routes/admin/index.ts
+++ b/routes/admin/index.ts
@@ -4,7 +4,9 @@ import { db, op, schema } from '@app/drizzle';
 import { production } from '@app/lib/config.ts';
 import * as image from '@app/lib/image/index.ts';
 import * as Subject from '@app/lib/subject/index.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { redirectIfNotLogin, requirePermission } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 import * as ep from './ep.ts';
@@ -73,7 +75,7 @@ export async function setup(app: App) {
         requirePermission('delete subject cover', (a) => a.permission.subject_cover_erase),
       ],
     },
-    async ({ params: { subjectID }, body: { imageID } }, res) => {
+    async ({ auth, params: { subjectID }, body: { imageID } }, res) => {
       const [i] = await db
         .select()
         .from(schema.chiiSubjectImgs)
@@ -84,6 +86,7 @@ export async function setup(app: App) {
         return res.status(404).send();
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         await image.deleteSubjectImage(i.imgTarget);
         await t

--- a/routes/demo/token/index.test.ts
+++ b/routes/demo/token/index.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { db, op, schema } from '@app/drizzle';
+import { emptyAuth } from '@app/lib/auth/index.ts';
+import { createTestServer } from '@app/tests/utils.ts';
+
+import { setup } from './index.ts';
+
+const testUserID = 987004;
+
+async function deleteTestTokens() {
+  await db
+    .delete(schema.chiiAccessToken)
+    .where(op.eq(schema.chiiAccessToken.userID, testUserID.toString()));
+}
+
+describe('demo tokens', () => {
+  beforeEach(deleteTestTokens);
+  afterEach(deleteTestTokens);
+
+  test('should create and delete access token', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: testUserID,
+      },
+    });
+    await app.register(setup);
+
+    const created = await app.inject({
+      method: 'post',
+      url: '/access-tokens',
+      body: {
+        name: 'test token',
+        days: 1,
+      },
+    });
+
+    expect(created.statusCode).toBe(200);
+    const token = created.json();
+    const [tokenRow] = await db
+      .select()
+      .from(schema.chiiAccessToken)
+      .where(
+        op.and(
+          op.eq(schema.chiiAccessToken.userID, testUserID.toString()),
+          op.eq(schema.chiiAccessToken.accessToken, token),
+        ),
+      )
+      .limit(1);
+    if (!tokenRow) {
+      throw new Error('missing token row');
+    }
+
+    const deleted = await app.inject({
+      method: 'delete',
+      url: '/access-tokens',
+      body: {
+        id: tokenRow.id,
+      },
+    });
+
+    expect(deleted.statusCode).toBe(200);
+    const [expired] = await db
+      .select()
+      .from(schema.chiiAccessToken)
+      .where(op.eq(schema.chiiAccessToken.id, tokenRow.id))
+      .limit(1);
+    expect(expired?.expiredAt.getTime()).toBeLessThan(tokenRow.expiredAt.getTime());
+  });
+});

--- a/routes/demo/token/index.ts
+++ b/routes/demo/token/index.ts
@@ -4,7 +4,9 @@ import t from 'typebox';
 import { db, op, schema } from '@app/drizzle';
 import { NotAllowedError } from '@app/lib/auth/index.ts';
 import { randomBase62String } from '@app/lib/utils/index.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { redirectIfNotLogin, requireLogin } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import { TokenType } from '@app/routes/oauth';
 import type { App } from '@app/routes/type.ts';
 
@@ -36,6 +38,7 @@ export function setup(app: App) {
         throw new NotAllowedError("delete a token not belong to you or token doesn't exist");
       }
 
+      await rateLimit(LimitAction.User, auth.userID);
       await db
         .update(schema.chiiAccessToken)
         .set({ expiredAt: new Date() })
@@ -59,6 +62,7 @@ export function setup(app: App) {
       preHandler: [requireLogin('delete your token')],
     },
     async ({ auth, body: { days, name } }) => {
+      await rateLimit(LimitAction.User, auth.userID);
       const token = await randomBase62String(40);
       await db.insert(schema.chiiAccessToken).values({
         userID: auth.userID.toString(),

--- a/routes/private/routes/group.test.ts
+++ b/routes/private/routes/group.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { db, op, schema } from '@app/drizzle';
 import { emptyAuth } from '@app/lib/auth/index.ts';
+import redis from '@app/lib/redis.ts';
 import { CommentState } from '@app/lib/topic/type.ts';
 import { createTestServer } from '@app/tests/utils.ts';
 
@@ -103,6 +104,7 @@ describe('group topics', () => {
   const testPostID = 101;
 
   beforeEach(async () => {
+    await redis.flushdb();
     await db.delete(schema.chiiGroupTopics).where(op.eq(schema.chiiGroupTopics.gid, testGroupID));
     await db.delete(schema.chiiGroupPosts).where(op.eq(schema.chiiGroupPosts.uid, testUserID));
     await db.insert(schema.chiiGroupTopics).values({
@@ -137,6 +139,7 @@ describe('group topics', () => {
   });
 
   afterEach(async () => {
+    await redis.flushdb();
     await db.delete(schema.chiiGroupTopics).where(op.eq(schema.chiiGroupTopics.gid, testGroupID));
     await db.delete(schema.chiiGroupPosts).where(op.eq(schema.chiiGroupPosts.uid, testUserID));
   });

--- a/routes/private/routes/group.ts
+++ b/routes/private/routes/group.ts
@@ -653,6 +653,7 @@ export async function setup(app: App) {
         }
       }
 
+      await rateLimit(LimitAction.Topic, auth.userID);
       await db.transaction(async (t) => {
         await t
           .update(schema.chiiGroupTopics)
@@ -860,6 +861,7 @@ export async function setup(app: App) {
         throw new NotAllowedError('edit a post with reply');
       }
 
+      await rateLimit(LimitAction.Reply, auth.userID);
       await db
         .update(schema.chiiGroupPosts)
         .set({ content })
@@ -900,6 +902,7 @@ export async function setup(app: App) {
         throw new NotAllowedError('delete reply not created by you');
       }
 
+      await rateLimit(LimitAction.Reply, auth.userID);
       await db
         .update(schema.chiiGroupPosts)
         .set({ state: CommentState.UserDelete })

--- a/routes/private/routes/index.test.ts
+++ b/routes/private/routes/index.test.ts
@@ -26,6 +26,7 @@ describe('index APIs', () => {
   let createdIndexId: number | null = null;
 
   beforeEach(async () => {
+    await redis.flushdb();
     vi.spyOn(DateTime, 'now').mockReturnValue(DateTime.fromSeconds(1020240000) as DateTime);
     await db
       .update(schema.chiiIndexes)
@@ -48,6 +49,7 @@ describe('index APIs', () => {
   });
 
   afterEach(async () => {
+    await redis.flushdb();
     vi.clearAllMocks();
     await db
       .update(schema.chiiIndexes)

--- a/routes/private/routes/index.ts
+++ b/routes/private/routes/index.ts
@@ -16,7 +16,9 @@ import * as fetcher from '@app/lib/types/fetcher.ts';
 import * as req from '@app/lib/types/req.ts';
 import * as res from '@app/lib/types/res.ts';
 import { formatErrors } from '@app/lib/types/res.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { requireLogin, requireTurnstileToken } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 // eslint-disable-next-line @typescript-eslint/require-await
@@ -40,6 +42,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('create index')],
     },
     async ({ auth, body }) => {
+      await rateLimit(LimitAction.IndexEdit, auth.userID);
       const now = DateTime.now().toUnixInteger();
       const title = body.title;
       const desc = body.desc;
@@ -144,6 +147,7 @@ export async function setup(app: App) {
         throw new NotAllowedError('update index related content which is not yours');
       }
 
+      await rateLimit(LimitAction.IndexEdit, auth.userID);
       const now = DateTime.now().toUnixInteger();
       const updateData: Partial<typeof schema.chiiIndexes.$inferInsert> = {
         title: body.title,
@@ -187,6 +191,7 @@ export async function setup(app: App) {
       if (index.uid !== auth.userID) {
         throw new NotAllowedError('delete index');
       }
+      await rateLimit(LimitAction.IndexEdit, auth.userID);
       await db
         .update(schema.chiiIndexes)
         .set({ ban: IndexPrivacy.Ban })
@@ -405,6 +410,7 @@ export async function setup(app: App) {
         throw new NotAllowedError('update index related content which is not yours');
       }
 
+      await rateLimit(LimitAction.IndexEdit, auth.userID);
       let type = 0;
       if (body.cat === IndexRelatedCategory.Subject) {
         const subject = await fetcher.fetchSlimSubjectByID(body.sid);
@@ -514,6 +520,7 @@ export async function setup(app: App) {
         throw new NotFoundError('index related item');
       }
 
+      await rateLimit(LimitAction.IndexEdit, auth.userID);
       await db
         .update(schema.chiiIndexRelated)
         .set({
@@ -570,6 +577,7 @@ export async function setup(app: App) {
         throw new NotFoundError('index related item');
       }
 
+      await rateLimit(LimitAction.IndexEdit, auth.userID);
       await db
         .update(schema.chiiIndexRelated)
         .set({ ban: 1 })

--- a/routes/private/routes/misc.test.ts
+++ b/routes/private/routes/misc.test.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
-import { db, schema } from '@app/drizzle';
+import { db, op, schema } from '@app/drizzle';
 import { emptyAuth } from '@app/lib/auth/index.ts';
 import { Notify, NotifyType } from '@app/lib/notify.ts';
 import { createTestServer } from '@app/tests/utils.ts';
@@ -45,5 +45,51 @@ describe('notify', () => {
 
     expect(res.statusCode).toBe(200);
     expect(Object.keys(res.json())).toContain('data');
+  });
+
+  test('should clear notify', async () => {
+    await db.transaction(async (t) => {
+      await Notify.create(t, {
+        destUserID: 287622,
+        sourceUserID: 382951,
+        mainID: 2,
+        createdAt: DateTime.now().toUnixInteger(),
+        type: NotifyType.GroupTopicReply,
+        title: 'tt',
+        relatedID: 1,
+      });
+    });
+
+    const [notification] = await db
+      .select()
+      .from(schema.chiiNotify)
+      .where(op.eq(schema.chiiNotify.uid, 287622))
+      .limit(1);
+    if (!notification) {
+      throw new Error('missing notification');
+    }
+
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: 287622,
+      },
+    });
+
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/clear-notify',
+      body: { id: [notification.id] },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [cleared] = await db
+      .select()
+      .from(schema.chiiNotify)
+      .where(op.eq(schema.chiiNotify.id, notification.id))
+      .limit(1);
+    expect(cleared?.unread).toBe(false);
   });
 });

--- a/routes/private/routes/misc.ts
+++ b/routes/private/routes/misc.ts
@@ -13,7 +13,9 @@ import { Security, Tag } from '@app/lib/openapi/index.ts';
 import { Subscriber } from '@app/lib/redis.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
 import * as res from '@app/lib/types/res.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { requireLogin } from '@app/routes/hooks/pre-handler';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 declare module 'fastify' {
@@ -140,6 +142,7 @@ export async function setup(app: App) {
         id = undefined;
       }
 
+      await rateLimit(LimitAction.User, userID);
       await Notify.markAllAsRead(userID, id);
       return {};
     },

--- a/routes/private/routes/privacy.ts
+++ b/routes/private/routes/privacy.ts
@@ -13,7 +13,9 @@ import {
   type PrivacyPatch,
   serializePrivacyRaw,
 } from '@app/lib/user/privacy.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { requireLogin } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 const PrivacyValue = t.String({
@@ -123,6 +125,7 @@ export async function setup(app: App) {
       // TypeBox widens enum strings here; patchPrivacyRaw performs runtime validation.
       const patch = body as PrivacyPatch;
       const nextPrivacy = serializePrivacyRaw(patchPrivacyRaw(privacy, patch));
+      await rateLimit(LimitAction.User, auth.userID);
       await db
         .update(schema.chiiUserFields)
         .set({ privacy: nextPrivacy })

--- a/routes/private/routes/subject.ts
+++ b/routes/private/routes/subject.ts
@@ -1372,6 +1372,7 @@ export async function setup(app: App) {
         }
       }
 
+      await rateLimit(LimitAction.Topic, auth.userID);
       await db.transaction(async (t) => {
         await t
           .update(schema.chiiSubjectTopics)
@@ -1579,6 +1580,7 @@ export async function setup(app: App) {
         throw new NotAllowedError('edit a post with reply');
       }
 
+      await rateLimit(LimitAction.Reply, auth.userID);
       await db
         .update(schema.chiiSubjectPosts)
         .set({ content })
@@ -1619,6 +1621,7 @@ export async function setup(app: App) {
         throw new NotAllowedError('delete reply not created by you');
       }
 
+      await rateLimit(LimitAction.Reply, auth.userID);
       await db
         .update(schema.chiiSubjectPosts)
         .set({ state: CommentState.UserDelete })

--- a/routes/private/routes/timeline.test.ts
+++ b/routes/private/routes/timeline.test.ts
@@ -147,6 +147,32 @@ describe('timeline status', () => {
     expect(data?.type).toBe(1);
     expect(data?.memo).toBe('^_^\n(bgm38)&gt;_&lt;');
   });
+
+  test('should delete timeline say', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: 287622,
+      },
+    });
+
+    await app.register(setup);
+    const id = await createTimelineSay(app, 'timeline to delete', []);
+
+    const res = await app.inject({
+      method: 'delete',
+      url: `/timeline/${id}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [data] = await db
+      .select()
+      .from(schema.chiiTimeline)
+      .where(op.eq(schema.chiiTimeline.id, id))
+      .limit(1);
+    expect(data).toBeUndefined();
+  });
 });
 
 describe('should get timeline events', () => {

--- a/routes/private/routes/timeline.ts
+++ b/routes/private/routes/timeline.ts
@@ -147,6 +147,7 @@ export async function setup(app: App) {
       if (timeline.uid !== auth.userID) {
         throw new NotAllowedError('delete timeline');
       }
+      await rateLimit(LimitAction.Timeline, auth.userID);
       await db.transaction(async (t) => {
         await t
           .delete(schema.chiiTimeline)

--- a/routes/private/routes/wiki/character/index.ts
+++ b/routes/private/routes/wiki/character/index.ts
@@ -582,6 +582,8 @@ export async function setup(app: App) {
         throw new ImageFileTooLarge();
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
+
       // validate image
       const resp = await imaginary.info(raw);
       const format = resp.type;
@@ -610,7 +612,6 @@ export async function setup(app: App) {
       // for example raw/36/b8/${character_id}_crt_36b8f84d-df4e-4d49-b662-bcde71a8764f.jpg"
       const filename = `raw/${h.slice(0, 2)}/${h.slice(2, 4)}/${characterID}_crt_${h}.${ext}`;
 
-      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         await t
           .update(schema.chiiCharacters)

--- a/routes/private/routes/wiki/character/index.ts
+++ b/routes/private/routes/wiki/character/index.ts
@@ -31,6 +31,7 @@ import * as res from '@app/lib/types/res.ts';
 import { formatErrors } from '@app/lib/types/res.ts';
 import { ghostUser } from '@app/lib/user/utils';
 import { parseConvertedValue } from '@app/lib/utils/index.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import {
   extractBirth,
   extractBloodType,
@@ -39,6 +40,7 @@ import {
   WikiChangedError,
 } from '@app/lib/wiki.ts';
 import { requireLogin } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 type IUserCharacterContribution = Static<typeof UserCharacterContribution>;
@@ -225,6 +227,7 @@ export async function setup(app: App) {
 
       let characterID;
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         const now = DateTime.now().toUnixInteger();
         const [{ insertId }] = await t.insert(schema.chiiCharacters).values({
@@ -437,6 +440,7 @@ export async function setup(app: App) {
         finalAuthorID = authorID;
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         const [p] = await t
           .select()
@@ -606,6 +610,7 @@ export async function setup(app: App) {
       // for example raw/36/b8/${character_id}_crt_36b8f84d-df4e-4d49-b662-bcde71a8764f.jpg"
       const filename = `raw/${h.slice(0, 2)}/${h.slice(2, 4)}/${characterID}_crt_${h}.${ext}`;
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         await t
           .update(schema.chiiCharacters)

--- a/routes/private/routes/wiki/person/index.ts
+++ b/routes/private/routes/wiki/person/index.ts
@@ -38,6 +38,7 @@ import * as res from '@app/lib/types/res.ts';
 import { formatErrors } from '@app/lib/types/res.ts';
 import { ghostUser } from '@app/lib/user/utils';
 import { parseConvertedValue } from '@app/lib/utils/index.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import {
   extractBirth,
   extractBloodType,
@@ -46,6 +47,7 @@ import {
   WikiChangedError,
 } from '@app/lib/wiki.ts';
 import { requireLogin } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 export const PersonCareers = [
@@ -257,6 +259,7 @@ export async function setup(app: App) {
 
       let personID;
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         const { producer, mangaka, artist, seiyu, writer, illustrator, actor } =
           person.profession ?? {};
@@ -491,6 +494,7 @@ export async function setup(app: App) {
         finalAuthorID = authorID;
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         const [p] = await t
           .select()
@@ -682,6 +686,7 @@ export async function setup(app: App) {
       // for example raw/36/b8/${person_id}_prsn_36b8f84d-df4e-4d49-b662-bcde71a8764f.jpg"
       const filename = `raw/${h.slice(0, 2)}/${h.slice(2, 4)}/${personID}_prsn_${h}.${ext}`;
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         await t
           .update(schema.chiiPersons)

--- a/routes/private/routes/wiki/person/index.ts
+++ b/routes/private/routes/wiki/person/index.ts
@@ -658,6 +658,8 @@ export async function setup(app: App) {
         throw new ImageFileTooLarge();
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
+
       // validate image
       const resp = await imaginary.info(raw);
       const format = resp.type;
@@ -686,7 +688,6 @@ export async function setup(app: App) {
       // for example raw/36/b8/${person_id}_prsn_36b8f84d-df4e-4d49-b662-bcde71a8764f.jpg"
       const filename = `raw/${h.slice(0, 2)}/${h.slice(2, 4)}/${personID}_prsn_${h}.${ext}`;
 
-      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         await t
           .update(schema.chiiPersons)

--- a/routes/private/routes/wiki/subject/ep.ts
+++ b/routes/private/routes/wiki/subject/ep.ts
@@ -14,8 +14,10 @@ import * as res from '@app/lib/types/res.ts';
 import { formatErrors } from '@app/lib/types/res.ts';
 import { validateDate } from '@app/lib/utils/date.ts';
 import { validateDuration } from '@app/lib/utils/index.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { matchExpected } from '@app/lib/wiki';
 import { requireLogin, requirePermission } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 // eslint-disable-next-line @typescript-eslint/require-await
@@ -215,6 +217,7 @@ export async function setup(app: App) {
 
       const now = DateTime.now().toUnixInteger();
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         await pushRev(t, {
           revisions: [

--- a/routes/private/routes/wiki/subject/image.ts
+++ b/routes/private/routes/wiki/subject/image.ts
@@ -21,7 +21,9 @@ import imaginary from '@app/lib/services/imaginary.ts';
 import * as Subject from '@app/lib/subject/index.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
 import * as res from '@app/lib/types/res.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { requireLogin, requirePermission } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 async function getSubjectInfo(subjectID: number) {
@@ -223,6 +225,7 @@ export function setup(app: App) {
         throw new LockedError();
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await uploadSubjectImage(filename, raw);
 
       await Subject.uploadCover({ subjectID: subjectID, filename, uid: auth.userID });
@@ -268,6 +271,7 @@ export function setup(app: App) {
         throw new NotFoundError(`image(id=${imageID}, subjectID=${subjectID})`);
       }
 
+      await rateLimit(LimitAction.Like, auth.userID);
       await db.insert(schema.chiiLikes).values({
         type: LikeType.SubjectCover,
         relatedID: imageID,
@@ -304,6 +308,7 @@ export function setup(app: App) {
       ],
     },
     async ({ params: { subjectID, imageID }, auth }) => {
+      await rateLimit(LimitAction.Like, auth.userID);
       const [result] = await db
         .update(schema.chiiLikes)
         .set({ deleted: true })

--- a/routes/private/routes/wiki/subject/image.ts
+++ b/routes/private/routes/wiki/subject/image.ts
@@ -188,6 +188,8 @@ export function setup(app: App) {
         throw new ImageFileTooLarge();
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
+
       // validate image
       const resp = await imaginary.info(raw);
       const format = resp.type;
@@ -225,7 +227,6 @@ export function setup(app: App) {
         throw new LockedError();
       }
 
-      await rateLimit(LimitAction.Wiki, auth.userID);
       await uploadSubjectImage(filename, raw);
 
       await Subject.uploadCover({ subjectID: subjectID, filename, uid: auth.userID });

--- a/routes/private/routes/wiki/subject/index.ts
+++ b/routes/private/routes/wiki/subject/index.ts
@@ -26,8 +26,10 @@ import { formatErrors } from '@app/lib/types/res.ts';
 import { ghostUser } from '@app/lib/user/utils';
 import { validateDate } from '@app/lib/utils/date.ts';
 import { parseConvertedValue, validateDuration } from '@app/lib/utils/index.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { matchExpected } from '@app/lib/wiki';
 import { requireLogin } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 import { getSubjectPlatforms } from '@app/vendor/index.ts';
 
@@ -333,6 +335,7 @@ export async function setup(app: App) {
         throw new NotAllowedError('edit subject');
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       const subjectID = await Subject.create({
         typeID: body.type,
         name: body.name,
@@ -532,6 +535,7 @@ export async function setup(app: App) {
 
       const body: Static<typeof SubjectEdit> = input;
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await Subject.edit({
         subjectID: subjectID,
         name: body.name,
@@ -666,6 +670,7 @@ export async function setup(app: App) {
         finalAuthorID = authorID;
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await Subject.edit({
         subjectID: subjectID,
         name: name,
@@ -757,6 +762,7 @@ export async function setup(app: App) {
         };
       });
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       const episodeIDs = await db.transaction(async (txn) => {
         const [{ insertId: firstEpID }] = await txn.insert(schema.chiiEpisodes).values(newEpisodes);
 
@@ -839,6 +845,7 @@ export async function setup(app: App) {
       if (episodeIDs.length !== new Set(episodeIDs).size) {
         throw new BadRequestError('episode ids are not unique');
       }
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         const eps = await t
           .select()

--- a/routes/private/routes/wiki/subject/mgr.ts
+++ b/routes/private/routes/wiki/subject/mgr.ts
@@ -5,7 +5,9 @@ import { db, op, schema } from '@app/drizzle';
 import { NotAllowedError } from '@app/lib/auth/index.ts';
 import { Tag } from '@app/lib/openapi/index.ts';
 import { RevType } from '@app/lib/rev/type.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { requireLogin } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 export function setup(app: App) {
@@ -30,6 +32,7 @@ export function setup(app: App) {
         throw new NotAllowedError('lock a subject');
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         await t
           .update(schema.chiiSubjects)
@@ -78,6 +81,7 @@ export function setup(app: App) {
         throw new NotAllowedError('unlock a subject');
       }
 
+      await rateLimit(LimitAction.Wiki, auth.userID);
       await db.transaction(async (t) => {
         await t
           .update(schema.chiiSubjects)

--- a/routes/private/routes/wiki/subject/subject.test.ts
+++ b/routes/private/routes/wiki/subject/subject.test.ts
@@ -344,6 +344,41 @@ describe('edit subject ', () => {
       userID: 100,
     });
   });
+
+  test('should patch subject', async () => {
+    const app = await testApp({
+      auth: {
+        groupID: UserGroup.Normal,
+        login: true,
+        permission: { subject_edit: true },
+        allowNsfw: true,
+        regTime: 0,
+        userID: 100,
+      },
+    });
+
+    const res = await app.inject({
+      url: '/subjects/1',
+      method: 'patch',
+      payload: {
+        commitMessage: 'patch summary',
+        expectedRevision: {},
+        subject: {
+          summary: 'patched summary',
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(editSubject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commitMessage: 'patch summary',
+        subjectID: 1,
+        summary: 'patched summary',
+        userID: 100,
+      }),
+    );
+  });
 });
 
 describe('should upload image', () => {

--- a/routes/private/routes/wiki/subject/subject.test.ts
+++ b/routes/private/routes/wiki/subject/subject.test.ts
@@ -9,6 +9,7 @@ import { db, op, schema } from '@app/drizzle';
 import { UserGroup } from '@app/lib/auth/index.ts';
 import { projectRoot } from '@app/lib/config.ts';
 import * as image from '@app/lib/image/index.ts';
+import redis from '@app/lib/redis.ts';
 import type { IImaginary, Info } from '@app/lib/services/imaginary.ts';
 import * as Subject from '@app/lib/subject/index.ts';
 import { SubjectType } from '@app/lib/subject/index.ts';
@@ -599,6 +600,14 @@ describe('patch episodes', () => {
       .orderBy(schema.chiiEpisodes.sort);
     episodeIDs = episodes.map((ep) => ep.id);
     expect(episodeIDs).toHaveLength(2);
+  });
+
+  beforeEach(async () => {
+    await redis.flushdb();
+  });
+
+  afterEach(async () => {
+    await redis.flushdb();
   });
 
   test('successfully patch episodes', async () => {


### PR DESCRIPTION
## Summary

Adjust the central user action rate limit rules and cover authenticated mutation routes that were missing rate limit checks. Existing shared helpers now also rate-limit comment edits/deletes and reaction removals, while index editing, user-owned state updates, and wiki edits use dedicated centralized actions. Wiki image uploads check quota before image inspection/conversion so rejected uploads do not spend work in the image pipeline.

| Action | Scope | Limit |
| --- | --- | --- |
| `subject` | 修改/添加条目收藏 | 5 分钟 15 次 |
| `character` | 修改/添加角色收藏 | 5 分钟 15 次 |
| `person` | 修改/添加人物收藏 | 5 分钟 15 次 |
| `index` | 修改/添加目录收藏 | 5 分钟 10 次 |
| `index-edit` | 创建/更新用户自己的目录内容 | 5 分钟 15 次 |
| `episode` | 更新章节进度 | 5 分钟 10 次 |
| `timeline` | 发送/删除时间线吐槽 | 5 分钟 5 次 |
| `like` | 点赞/取消点赞 | 1 分钟 10 次 |
| `report` | 报告疑虑 | 5 分钟 5 次 |
| `comment` | 发表/编辑/删除吐槽 | 5 分钟 15 次 |
| `topic` | 创建/编辑小组话题和条目讨论 | 10 分钟 2 次 |
| `reply` | 回复/编辑/删除小组话题和条目讨论 | 5 分钟 15 次 |
| `relationship` | 添加/删除好友和黑名单 | 5 分钟 10 次 |
| `user` | 更新用户自己的设置或轻量状态 | 5 分钟 10 次 |
| `wiki` | 创建或更新 Wiki 内容 | 5 分钟 10 次 |

Remaining write-method endpoints outside this user-action limiter are auth/OAuth protocol endpoints and POST search endpoints; those are not user content mutations.

## Validation

- GitHub checks on `a8a5e6c8`: `build`, `lint`, `test`, `CodeQL`, and `codecov/project` passed.
- `pnpm exec eslint -c eslint.config.mjs ...` on changed source and test files.
- `pnpm exec prettier --check ...` on changed source and test files.
- `pnpm run tsc --noEmit --pretty false`
- `git diff --check`

Targeted route tests were attempted locally with a Redis override, but local MySQL test service was unavailable, so local integration tests could not complete outside CI.
