### PR TITLE
feat: add passkey (WebAuthn) login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,5 @@ Key infrastructure: MySQL (TypeORM), Redis (ioredis), Kafka (@confluentinc/kafka
 - Notification types defined in `lib/notify.ts`
 - Kafka topic handlers registered in `bin/mq.ts` serviceHandlers map
 - Husky + lint-staged for pre-commit hooks
+- TypeBox schema variables 使用 PascalCase（如 `ChallengePayloadSchema`）
+- 对应的 `Static<typeof ...>` 类型使用 `I` 前缀命名（如 `IChallengePayload`）

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,6 +25,11 @@ turnstile:
   secretKey: '1x0000000000000000000000000000000AA' # TURNSTILE_SECRET_KEY
   siteKey: '1x00000000000000000000AA' # TURNSTILE_SITE_KEY
 
+passkey:
+  rpName: 'Bangumi'
+  rpIds: 'bgm.tv,bangumi.tv,chii.in'
+  origins: 'https://bgm.tv,https://bangumi.tv,https://chii.in'
+
 sentryDSN: 'https://examplePublicKey@o0.ingest.sentry.io/0' # SENTRY_DSN
 
 image:

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -778,3 +778,20 @@ export const chiiIssues = mysqlTable('chii_issues', {
   related: mediumint('isu_related').notNull(),
   createdAt: int('isu_dateline').notNull(),
 });
+
+export const chiiPasskeyCredentials = mysqlTable('chii_passkey_credentials', {
+  id: int('id').autoincrement().notNull(),
+  uid: mediumint('uid').notNull(),
+  rpId: varchar('rp_id', { length: 64 }).notNull(),
+  credentialId: varchar('credential_id', { length: 255 }).notNull(),
+  publicKey: mediumtext('public_key').notNull(),
+  webauthnUserId: varchar('webauthn_user_id', { length: 128 }).notNull(),
+  signCount: int('sign_count').default(0).notNull(),
+  transports: mediumtext('transports').notNull(),
+  deviceType: varchar('device_type', { length: 32 }).default('').notNull(),
+  backedUp: tinyint('backed_up').default(0).notNull(),
+  nickname: varchar('nickname', { length: 80 }).default('').notNull(),
+  createdAt: int('created_at').notNull(),
+  lastUsedAt: int('last_used_at').default(0).notNull(),
+  revokedAt: int('revoked_at').default(0).notNull(),
+});

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -151,6 +151,12 @@ export const schema = Obj({
 
   sentryDSN: t.Optional(t.String({ env: 'SENTRY_DSN' })),
 
+  passkey: Obj({
+    rpName: t.String({ default: 'Bangumi' }),
+    rpIds: t.String({ default: 'bgm.tv,bangumi.tv,chii.in' }),
+    origins: t.String({ default: 'https://bgm.tv,https://bangumi.tv,https://chii.in' }),
+  }),
+
   mysql: Obj({
     db: t.String({ default: 'bangumi', env: 'MYSQL_DB' }),
     host: t.String({ default: '127.0.0.1', env: 'MYSQL_HOST' }),

--- a/lib/passkey/challenge.ts
+++ b/lib/passkey/challenge.ts
@@ -4,9 +4,11 @@ import { Value } from 'typebox/value';
 
 import redis from '@app/lib/redis.ts';
 
-import { hashSHA256, randomBase64Url } from './webauthn.ts';
+import { hashSHA256 } from './webauthn.ts';
 
 export interface CreateChallengeParams {
+  /** Challenge string from SDK-generated options.challenge */
+  challenge: string;
   uid: number;
   type: 'register' | 'login';
   rpId: string;
@@ -26,7 +28,6 @@ export interface ChallengeData {
 const challengeTTL = 300; // 5 minutes
 
 /** Schema for Redis-stored challenge data — guards against stale payloads after code updates */
-/** Schema for Redis-stored challenge data — guards against stale payloads after code updates */
 const ChallengePayloadSchema = t.Object({
   uid: t.Integer(),
   type: t.Union([t.Literal('register'), t.Literal('login')]),
@@ -43,9 +44,8 @@ function challengeKey(challenge: string): string {
 }
 
 export async function createChallenge(params: CreateChallengeParams): Promise<ChallengeData> {
-  const challenge = randomBase64Url(32);
   const data: ChallengeData = {
-    challenge,
+    challenge: params.challenge,
     uid: params.uid,
     type: params.type,
     rpId: params.rpId,
@@ -61,7 +61,7 @@ export async function createChallenge(params: CreateChallengeParams): Promise<Ch
     userAgentHash: params.userAgent ? hashSHA256(params.userAgent) : '',
   };
 
-  await redis.setex(challengeKey(challenge), challengeTTL, JSON.stringify(payload));
+  await redis.setex(challengeKey(params.challenge), challengeTTL, JSON.stringify(payload));
 
   return data;
 }

--- a/lib/passkey/challenge.ts
+++ b/lib/passkey/challenge.ts
@@ -73,8 +73,10 @@ export async function consumeChallenge(
   uid?: number,
 ): Promise<ChallengeData | null> {
   const key = challengeKey(challenge);
-  const raw = await redis.get(key);
 
+  // GETDEL is atomic: get the value and delete the key in one operation,
+  // ensuring one-time consumption without TOCTOU race condition.
+  const raw = await redis.getdel(key);
   if (!raw) {
     return null;
   }
@@ -91,12 +93,6 @@ export async function consumeChallenge(
   }
 
   if (uid !== undefined && stored.uid !== uid) {
-    return null;
-  }
-
-  // Delete atomically to ensure one-time consumption
-  const deleted = await redis.del(key);
-  if (deleted === 0) {
     return null;
   }
 

--- a/lib/passkey/challenge.ts
+++ b/lib/passkey/challenge.ts
@@ -1,0 +1,110 @@
+import type { Static } from 'typebox';
+import t from 'typebox';
+import { Value } from 'typebox/value';
+
+import redis from '@app/lib/redis.ts';
+
+import { hashSHA256, randomBase64Url } from './webauthn.ts';
+
+export interface CreateChallengeParams {
+  uid: number;
+  type: 'register' | 'login';
+  rpId: string;
+  ip?: string;
+  userAgent?: string;
+  webauthnUserId?: string;
+}
+
+export interface ChallengeData {
+  challenge: string;
+  uid: number;
+  type: 'register' | 'login';
+  rpId: string;
+  webauthnUserId: string;
+}
+
+const challengeTTL = 300; // 5 minutes
+
+/** Schema for Redis-stored challenge data — guards against stale payloads after code updates */
+/** Schema for Redis-stored challenge data — guards against stale payloads after code updates */
+const ChallengePayloadSchema = t.Object({
+  uid: t.Integer(),
+  type: t.Union([t.Literal('register'), t.Literal('login')]),
+  rpId: t.String({ minLength: 1 }),
+  webauthnUserId: t.String(),
+  ip: t.String(),
+  userAgentHash: t.String(),
+});
+
+type IChallengePayload = Static<typeof ChallengePayloadSchema>;
+
+function challengeKey(challenge: string): string {
+  return `passkey:challenge:${challenge}`;
+}
+
+export async function createChallenge(params: CreateChallengeParams): Promise<ChallengeData> {
+  const challenge = randomBase64Url(32);
+  const data: ChallengeData = {
+    challenge,
+    uid: params.uid,
+    type: params.type,
+    rpId: params.rpId,
+    webauthnUserId: params.webauthnUserId ?? '',
+  };
+
+  const payload: IChallengePayload = {
+    uid: data.uid,
+    type: data.type,
+    rpId: data.rpId,
+    webauthnUserId: data.webauthnUserId,
+    ip: params.ip ?? '',
+    userAgentHash: params.userAgent ? hashSHA256(params.userAgent) : '',
+  };
+
+  await redis.setex(challengeKey(challenge), challengeTTL, JSON.stringify(payload));
+
+  return data;
+}
+
+export async function consumeChallenge(
+  challenge: string,
+  type: 'register' | 'login',
+  rpId: string,
+  uid?: number,
+): Promise<ChallengeData | null> {
+  const key = challengeKey(challenge);
+  const raw = await redis.get(key);
+
+  if (!raw) {
+    return null;
+  }
+
+  let stored: IChallengePayload;
+  try {
+    stored = Value.Parse(ChallengePayloadSchema, JSON.parse(raw));
+  } catch {
+    return null;
+  }
+
+  if (stored.type !== type || stored.rpId !== rpId) {
+    return null;
+  }
+
+  if (uid !== undefined && stored.uid !== uid) {
+    return null;
+  }
+
+  // Delete atomically to ensure one-time consumption
+  const deleted = await redis.del(key);
+  if (deleted === 0) {
+    return null;
+  }
+
+  return {
+    challenge,
+    uid: stored.uid,
+    type: stored.type,
+    rpId: stored.rpId,
+    webauthnUserId: stored.webauthnUserId,
+  };
+}

--- a/lib/passkey/credential.ts
+++ b/lib/passkey/credential.ts
@@ -1,0 +1,84 @@
+import { createError } from '@fastify/error';
+import httpCodes from 'http-status-codes';
+import t from 'typebox';
+import { Value } from 'typebox/value';
+
+import { db, op, schema } from '@app/drizzle';
+
+export const PasskeyNotFoundError = createError<[]>(
+  'PASSKEY_NOT_FOUND',
+  'passkey not found',
+  httpCodes.NOT_FOUND,
+);
+
+export interface PasskeyCredential {
+  id: number;
+  uid: number;
+  rpId: string;
+  credentialId: string;
+  publicKey: string;
+  webauthnUserId: string;
+  signCount: number;
+  transports: string[];
+  deviceType: string;
+  backedUp: boolean;
+  nickname: string;
+  createdAt: number;
+  lastUsedAt: number;
+  revokedAt: number;
+}
+
+const TransportsSchema = t.Array(t.String());
+
+function parseTransports(raw: string): string[] {
+  return Value.Parse(TransportsSchema, JSON.parse(raw));
+}
+
+function formatCredential(
+  row: typeof schema.chiiPasskeyCredentials.$inferSelect,
+): PasskeyCredential {
+  return {
+    id: row.id,
+    uid: row.uid,
+    rpId: row.rpId,
+    credentialId: row.credentialId,
+    publicKey: row.publicKey,
+    webauthnUserId: row.webauthnUserId,
+    signCount: row.signCount,
+    transports: parseTransports(row.transports),
+    deviceType: row.deviceType,
+    backedUp: row.backedUp === 1,
+    nickname: row.nickname,
+    createdAt: row.createdAt,
+    lastUsedAt: row.lastUsedAt,
+    revokedAt: row.revokedAt,
+  };
+}
+
+export async function fetchCredentialByCredentialId(
+  credentialId: string,
+  rpId: string,
+  uid?: number,
+): Promise<PasskeyCredential | null> {
+  const conditions = op.and(
+    op.eq(schema.chiiPasskeyCredentials.credentialId, credentialId),
+    op.eq(schema.chiiPasskeyCredentials.rpId, rpId),
+    op.eq(schema.chiiPasskeyCredentials.revokedAt, 0),
+    uid === undefined ? undefined : op.eq(schema.chiiPasskeyCredentials.uid, uid),
+  );
+
+  const [row] = await db.select().from(schema.chiiPasskeyCredentials).where(conditions).limit(1);
+
+  return row ? formatCredential(row) : null;
+}
+
+export async function markCredentialUsed(id: number, newCounter: number) {
+  const now = Math.floor(Date.now() / 1000);
+  await db
+    .update(schema.chiiPasskeyCredentials)
+    .set({
+      signCount: newCounter,
+      lastUsedAt: now,
+    })
+    .where(op.eq(schema.chiiPasskeyCredentials.id, id));
+}

--- a/lib/passkey/index.ts
+++ b/lib/passkey/index.ts
@@ -1,0 +1,3 @@
+export * from './challenge.ts';
+export * from './credential.ts';
+export * from './webauthn.ts';

--- a/lib/passkey/webauthn.ts
+++ b/lib/passkey/webauthn.ts
@@ -1,0 +1,132 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+import {
+  type AuthenticationResponseJSON,
+  type AuthenticatorTransportFuture,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type { Static } from 'typebox';
+import t from 'typebox';
+
+export function base64UrlToBuffer(value: string): Uint8Array {
+  return Buffer.from(value, 'base64url');
+}
+
+export function randomBase64Url(bytes = 32): string {
+  return randomBytes(bytes).toString('base64url');
+}
+
+export function hashSHA256(data: string): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+/** TypeBox schema for validating the client's WebAuthn authentication response */
+export const AuthenticationResponseSchema = t.Object(
+  {
+    id: t.String(),
+    rawId: t.String(),
+    type: t.String(),
+    response: t.Object({
+      clientDataJSON: t.String(),
+      authenticatorData: t.String(),
+      signature: t.String(),
+      userHandle: t.Optional(t.String()),
+    }),
+    clientExtensionResults: t.Object({}, { additionalProperties: true }),
+  },
+  { additionalProperties: true },
+);
+
+export type IAuthenticationResponse = Static<typeof AuthenticationResponseSchema>;
+
+const validTransports = new Set<string>([
+  'ble',
+  'cable',
+  'hybrid',
+  'internal',
+  'nfc',
+  'smart-card',
+  'usb',
+]);
+
+function castTransports(transports?: string[]): AuthenticatorTransportFuture[] | undefined {
+  if (!transports) return undefined;
+  for (const t of transports) {
+    if (!validTransports.has(t)) {
+      throw new Error(`invalid transport: ${t}`);
+    }
+  }
+  return transports as AuthenticatorTransportFuture[];
+}
+
+export async function generatePasskeyAuthenticationOptions(params: {
+  rpId: string;
+  challenge: string;
+  credentials?: { credentialId: string; transports?: string[] }[];
+}) {
+  const credentials = params.credentials ?? [];
+  if (credentials.length > 0) {
+    const options = await generateAuthenticationOptions({
+      rpID: params.rpId,
+      challenge: params.challenge,
+      userVerification: 'required',
+      allowCredentials: credentials.map((cred) => ({
+        id: cred.credentialId,
+        transports: castTransports(cred.transports),
+      })),
+    });
+    return { options };
+  }
+
+  // Usernameless mode: no allowCredentials — browser shows native account selector
+  const options = await generateAuthenticationOptions({
+    rpID: params.rpId,
+    challenge: params.challenge,
+    userVerification: 'required',
+  });
+
+  const cleanOptions = { ...options, allowCredentials: undefined };
+  return { options: cleanOptions };
+}
+
+export async function verifyPasskeyAuthentication(params: {
+  rpId: string;
+  origin: string;
+  expectedChallenge: string;
+  credential: {
+    credentialId: string;
+    publicKey: string;
+    counter: number;
+    transports?: string[];
+    webauthnUserId?: string;
+  };
+  response: IAuthenticationResponse;
+}) {
+  const result = await verifyAuthenticationResponse({
+    response: params.response as unknown as AuthenticationResponseJSON,
+    expectedChallenge: params.expectedChallenge,
+    expectedOrigin: params.origin,
+    expectedRPID: params.rpId,
+    credential: {
+      id: params.credential.credentialId,
+      publicKey: base64UrlToBuffer(params.credential.publicKey),
+      counter: params.credential.counter,
+      transports: castTransports(params.credential.transports),
+    },
+    requireUserVerification: true,
+  });
+
+  const info = result.authenticationInfo;
+  const userHandle = params.response.response.userHandle ?? '';
+  const expectedUserHandle = params.credential.webauthnUserId ?? '';
+  const userHandleMatches = !expectedUserHandle || !userHandle || userHandle === expectedUserHandle;
+
+  return {
+    verified: result.verified && userHandleMatches,
+    credentialId: info?.credentialID ?? params.credential.credentialId,
+    newCounter: info?.newCounter ?? params.credential.counter,
+    userVerified: info?.userVerified,
+    userHandle,
+  };
+}

--- a/lib/passkey/webauthn.ts
+++ b/lib/passkey/webauthn.ts
@@ -1,13 +1,13 @@
 import { createHash, randomBytes } from 'node:crypto';
 
 import {
-  type AuthenticationResponseJSON,
   type AuthenticatorTransportFuture,
   generateAuthenticationOptions,
   verifyAuthenticationResponse,
 } from '@simplewebauthn/server';
 import type { Static } from 'typebox';
 import t from 'typebox';
+import { Value } from 'typebox/value';
 
 export function base64UrlToBuffer(value: string): Uint8Array {
   return Buffer.from(value, 'base64url');
@@ -26,7 +26,7 @@ export const AuthenticationResponseSchema = t.Object(
   {
     id: t.String(),
     rawId: t.String(),
-    type: t.String(),
+    type: t.Literal('public-key'),
     response: t.Object({
       clientDataJSON: t.String(),
       authenticatorData: t.String(),
@@ -62,14 +62,12 @@ function castTransports(transports?: string[]): AuthenticatorTransportFuture[] |
 
 export async function generatePasskeyAuthenticationOptions(params: {
   rpId: string;
-  challenge: string;
   credentials?: { credentialId: string; transports?: string[] }[];
 }) {
   const credentials = params.credentials ?? [];
   if (credentials.length > 0) {
     const options = await generateAuthenticationOptions({
       rpID: params.rpId,
-      challenge: params.challenge,
       userVerification: 'required',
       allowCredentials: credentials.map((cred) => ({
         id: cred.credentialId,
@@ -82,7 +80,6 @@ export async function generatePasskeyAuthenticationOptions(params: {
   // Usernameless mode: no allowCredentials — browser shows native account selector
   const options = await generateAuthenticationOptions({
     rpID: params.rpId,
-    challenge: params.challenge,
     userVerification: 'required',
   });
 
@@ -101,10 +98,11 @@ export async function verifyPasskeyAuthentication(params: {
     transports?: string[];
     webauthnUserId?: string;
   };
-  response: IAuthenticationResponse;
+  response: unknown;
 }) {
+  const response = Value.Parse(AuthenticationResponseSchema, params.response);
   const result = await verifyAuthenticationResponse({
-    response: params.response as unknown as AuthenticationResponseJSON,
+    response: response,
     expectedChallenge: params.expectedChallenge,
     expectedOrigin: params.origin,
     expectedRPID: params.rpId,
@@ -118,7 +116,7 @@ export async function verifyPasskeyAuthentication(params: {
   });
 
   const info = result.authenticationInfo;
-  const userHandle = params.response.response.userHandle ?? '';
+  const userHandle = response.response.userHandle ?? '';
   const expectedUserHandle = params.credential.webauthnUserId ?? '';
   const userHandleMatches = !expectedUserHandle || !userHandle || userHandle === expectedUserHandle;
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@fastify/view": "12.0.0",
     "@node-rs/bcrypt": "1.10.7",
     "@sentry/node": "10.62.0",
+    "@simplewebauthn/server": "13.1.2",
     "@trim21/php-serialize": "0.2.2",
     "ajv": "8.20.0",
     "ajv-formats": "3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.12.1
       '@confluentinc/kafka-javascript':
         specifier: 1.9.1
-        version: 1.9.1
+        version: 1.9.1(supports-color@5.5.0)
       '@fastify/cookie':
         specifier: 11.0.2
         version: 11.0.2
@@ -40,7 +40,7 @@ importers:
         version: 9.1.3
       '@fastify/swagger':
         specifier: 9.7.0
-        version: 9.7.0
+        version: 9.7.0(supports-color@5.5.0)
       '@fastify/type-provider-typebox':
         specifier: 6.1.0
         version: 6.1.0(typebox@1.3.2)
@@ -52,7 +52,10 @@ importers:
         version: 1.10.7
       '@sentry/node':
         specifier: 10.62.0
-        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
+        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0)
+      '@simplewebauthn/server':
+        specifier: 13.1.2
+        version: 13.1.2
       '@trim21/php-serialize':
         specifier: 0.2.2
         version: 0.2.2
@@ -85,7 +88,7 @@ importers:
         version: 13.2.1(fastify@5.9.0)
       fastify-socket.io:
         specifier: 5.1.0
-        version: 5.1.0(fastify@5.9.0)(socket.io@4.8.3)
+        version: 5.1.0(fastify@5.9.0)(socket.io@4.8.3(supports-color@5.5.0))
       got:
         specifier: 15.0.7
         version: 15.0.7
@@ -94,16 +97,16 @@ importers:
         version: 16.14.2
       http-proxy-agent:
         specifier: 9.1.0
-        version: 9.1.0
+        version: 9.1.0(supports-color@5.5.0)
       http-status-codes:
         specifier: 2.3.0
         version: 2.3.0
       https-proxy-agent:
         specifier: 9.1.0
-        version: 9.1.0
+        version: 9.1.0(supports-color@5.5.0)
       ioredis:
         specifier: 5.11.1
-        version: 5.11.1
+        version: 5.11.1(supports-color@5.5.0)
       js-yaml:
         specifier: 4.3.0
         version: 4.3.0
@@ -154,10 +157,10 @@ importers:
         version: 0.2.2
       socket.io:
         specifier: 4.8.3
-        version: 4.8.3
+        version: 4.8.3(supports-color@5.5.0)
       socks-proxy-agent:
         specifier: 10.1.0
-        version: 10.1.0
+        version: 10.1.0(supports-color@5.5.0)
       typebox:
         specifier: 1.3.2
         version: 1.3.2
@@ -170,10 +173,10 @@ importers:
         version: 1.70.0
       '@bufbuild/protoc-gen-es':
         specifier: 2.12.0
-        version: 2.12.0(@bufbuild/protobuf@2.12.1)
+        version: 2.12.0(@bufbuild/protobuf@2.12.1)(supports-color@5.5.0)
       '@eslint/js':
         specifier: 10.0.1
-        version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
+        version: 10.0.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       '@graphql-codegen/cli':
         specifier: 7.1.2
         version: 7.1.2(@fastify/websocket@11.2.0)(@types/node@24.12.4)(graphql@16.14.2)(typescript@6.0.3)
@@ -209,13 +212,13 @@ importers:
         version: 24.12.4
       '@typescript-eslint/eslint-plugin':
         specifier: 8.60.1
-        version: 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: 8.60.1
-        version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
       '@typescript-eslint/utils':
         specifier: 8.60.1
-        version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3)
       '@vitest/coverage-v8':
         specifier: 4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -236,28 +239,28 @@ importers:
         version: 1.22.0(esbuild@0.28.1)
       eslint:
         specifier: 10.4.1
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@10.4.1(jiti@2.7.0))
+        version: 10.1.8(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       eslint-plugin-erasable-syntax-only:
         specifier: 0.4.1
-        version: 0.4.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 0.4.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3)
       eslint-plugin-promise:
         specifier: 7.3.0
-        version: 7.3.0(eslint@10.4.1(jiti@2.7.0))
+        version: 7.3.0(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       eslint-plugin-simple-import-sort:
         specifier: 13.0.0
-        version: 13.0.0(eslint@10.4.1(jiti@2.7.0))
+        version: 13.0.0(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       eslint-plugin-tsdoc:
         specifier: 0.5.2
-        version: 0.5.2(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 0.5.2(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
       eslint-plugin-unicorn:
         specifier: 70.0.0
-        version: 70.0.0(eslint@10.4.1(jiti@2.7.0))
+        version: 70.0.0(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       eslint-plugin-unused-imports:
         specifier: 4.4.1
-        version: 4.4.1(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       graphql-tag:
         specifier: 2.12.6
         version: 2.12.6(graphql@16.14.2)
@@ -266,7 +269,7 @@ importers:
         version: 9.1.7
       ioredis-mock:
         specifier: 8.13.1
-        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.11.1))(ioredis@5.11.1)
+        version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.11.1))(ioredis@5.11.1(supports-color@5.5.0))
       lint-staged:
         specifier: 17.0.7
         version: 17.0.7
@@ -284,7 +287,7 @@ importers:
         version: 3.8.3
       prettier-plugin-jsdoc:
         specifier: 1.8.1
-        version: 1.8.1(prettier@3.8.3)
+        version: 1.8.1(prettier@3.8.3)(supports-color@5.5.0)
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -299,7 +302,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: 8.60.1
-        version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3)
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -1414,6 +1417,9 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  '@hexagon/base64@1.1.28':
+    resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1597,6 +1603,9 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
+  '@levischuck/tiny-cbor@0.2.11':
+    resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
+
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
@@ -1763,6 +1772,24 @@ packages:
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
+  '@peculiar/asn1-android@2.8.0':
+    resolution: {integrity: sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA==}
+
+  '@peculiar/asn1-ecc@2.8.0':
+    resolution: {integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==}
+
+  '@peculiar/asn1-rsa@2.8.0':
+    resolution: {integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/asn1-x509@2.8.0':
+    resolution: {integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -1922,6 +1949,10 @@ packages:
     resolution: {integrity: sha512-yzC+6bJemVnrEgddztLuX5I7zSoRrxXgS5j7BVS6HzVs9sMf8Fx+bdIEDkKu4bBBBKSzuen1SLVfq9u3z9L1wQ==}
     peerDependencies:
       prettier: ^2.0.0 || ^3.0.0
+
+  '@simplewebauthn/server@13.1.2':
+    resolution: {integrity: sha512-VwoDfvLXSCaRiD+xCIuyslU0HLxVggeE5BL06+GbsP2l1fGf5op8e0c3ZtKoi+vSg1q4ikjtAghC23ze2Q3H9g==}
+    engines: {node: '>=20.0.0'}
 
   '@sindresorhus/is@8.1.0':
     resolution: {integrity: sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==}
@@ -2280,6 +2311,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -4025,6 +4060,13 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   qlobber@8.0.1:
     resolution: {integrity: sha512-O+Wd1chXj5YE1DwmD+ae0bXiSLehmnS3czlC1R9FL/Nt/3q8uMS1bIHmg2lJfCoiimCxClWM8AAuJrF0EvNiog==}
     engines: {node: '>= 16'}
@@ -4693,7 +4735,7 @@ snapshots:
       semifies: 1.0.0
       source-map: 0.6.1
 
-  '@apm-js-collab/tracing-hooks@0.10.1':
+  '@apm-js-collab/tracing-hooks@0.10.1(supports-color@5.5.0)':
     dependencies:
       '@apm-js-collab/code-transformer': 0.15.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -4928,7 +4970,7 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -4975,7 +5017,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -4999,9 +5041,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.7': {}
@@ -5068,25 +5110,25 @@ snapshots:
 
   '@bufbuild/protobuf@2.12.1': {}
 
-  '@bufbuild/protoc-gen-es@2.12.0(@bufbuild/protobuf@2.12.1)':
+  '@bufbuild/protoc-gen-es@2.12.0(@bufbuild/protobuf@2.12.1)(supports-color@5.5.0)':
     dependencies:
-      '@bufbuild/protoplugin': 2.12.0
+      '@bufbuild/protoplugin': 2.12.0(supports-color@5.5.0)
     optionalDependencies:
       '@bufbuild/protobuf': 2.12.1
     transitivePeerDependencies:
       - supports-color
 
-  '@bufbuild/protoplugin@2.12.0':
+  '@bufbuild/protoplugin@2.12.0(supports-color@5.5.0)':
     dependencies:
       '@bufbuild/protobuf': 2.12.0
-      '@typescript/vfs': 1.6.4(typescript@5.4.5)
+      '@typescript/vfs': 1.6.4(supports-color@5.5.0)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@confluentinc/kafka-javascript@1.9.1':
+  '@confluentinc/kafka-javascript@1.9.1(supports-color@5.5.0)':
     dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3
+      '@mapbox/node-pre-gyp': 2.0.3(supports-color@5.5.0)
       bindings: 1.5.0
       nan: 2.28.0
     transitivePeerDependencies:
@@ -5376,14 +5418,14 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))':
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@5.5.0)':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@5.5.0)
@@ -5399,9 +5441,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.4.1(jiti@2.7.0))':
+  '@eslint/js@10.0.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))':
     optionalDependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -5477,10 +5519,10 @@ snapshots:
       fastq: 1.20.1
       glob: 13.0.6
 
-  '@fastify/swagger@9.7.0':
+  '@fastify/swagger@9.7.0(supports-color@5.5.0)':
     dependencies:
       fastify-plugin: 5.1.0
-      json-schema-resolver: 3.0.0
+      json-schema-resolver: 3.0.0(supports-color@5.5.0)
       openapi-types: 12.1.3
       rfdc: 1.4.1
       yaml: 2.9.0
@@ -5811,9 +5853,9 @@ snapshots:
 
   '@graphql-tools/graphql-tag-pluck@8.3.31(graphql@16.14.2)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/parser': 7.29.7
-      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@graphql-tools/utils': 11.1.0(graphql@16.14.2)
@@ -5912,6 +5954,8 @@ snapshots:
   '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
     dependencies:
       graphql: 16.14.2
+
+  '@hexagon/base64@1.1.28': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -6077,13 +6121,15 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
+  '@levischuck/tiny-cbor@0.2.11': {}
+
   '@lukeed/ms@2.0.2': {}
 
-  '@mapbox/node-pre-gyp@2.0.3':
+  '@mapbox/node-pre-gyp@2.0.3(supports-color@5.5.0)':
     dependencies:
       consola: 3.4.2
       detect-libc: 2.1.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.8.5
@@ -6199,12 +6245,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.214.0
       import-in-the-middle: 3.2.0
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6224,6 +6270,43 @@ snapshots:
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@peculiar/asn1-android@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
 
   '@pinojs/redact@0.4.0': {}
 
@@ -6286,7 +6369,7 @@ snapshots:
 
   '@sentry/core@10.62.0': {}
 
-  '@sentry/node-core@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.62.0
@@ -6295,19 +6378,19 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
-  '@sentry/node@10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node@10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.62.0
-      '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+      '@sentry/node-core': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
       '@sentry/opentelemetry': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      '@sentry/server-utils': 10.62.0
+      '@sentry/server-utils': 10.62.0(supports-color@5.5.0)
       import-in-the-middle: 3.2.0
     transitivePeerDependencies:
       - '@opentelemetry/core'
@@ -6322,11 +6405,11 @@ snapshots:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.62.0
 
-  '@sentry/server-utils@10.62.0':
+  '@sentry/server-utils@10.62.0(supports-color@5.5.0)':
     dependencies:
       '@apm-js-collab/code-transformer': 0.15.0
       '@apm-js-collab/code-transformer-bundler-plugins': 0.5.0
-      '@apm-js-collab/tracing-hooks': 0.10.1
+      '@apm-js-collab/tracing-hooks': 0.10.1(supports-color@5.5.0)
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.62.0
       magic-string: 0.30.21
@@ -6343,6 +6426,16 @@ snapshots:
       '@shopify/liquid-html-parser': 2.9.2
       html-styles: 1.0.0
       prettier: 3.8.3
+
+  '@simplewebauthn/server@13.1.2':
+    dependencies:
+      '@hexagon/base64': 1.1.28
+      '@levischuck/tiny-cbor': 0.2.11
+      '@peculiar/asn1-android': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
 
   '@sindresorhus/is@8.1.0': {}
 
@@ -6427,7 +6520,7 @@ snapshots:
 
   '@types/ioredis-mock@8.2.7(ioredis@5.11.1)':
     dependencies:
-      ioredis: 5.11.1
+      ioredis: 5.11.1(supports-color@5.5.0)
 
   '@types/js-yaml@4.0.9': {}
 
@@ -6459,15 +6552,15 @@ snapshots:
     dependencies:
       '@types/node': 24.12.4
 
-  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.60.1
-      '@typescript-eslint/type-utils': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.60.1
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -6475,19 +6568,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.60.1
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.1(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.56.1(supports-color@5.5.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.60.1
@@ -6523,13 +6616,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6539,9 +6632,9 @@ snapshots:
 
   '@typescript-eslint/types@8.60.1': {}
 
-  '@typescript-eslint/typescript-estree@8.56.1(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.56.1(supports-color@5.5.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.1(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.56.1(supports-color@5.5.0)(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
@@ -6569,24 +6662,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@6.0.3)
-      eslint: 10.4.1(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.56.1(supports-color@5.5.0)(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/types': 8.60.1
       '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6601,7 +6694,7 @@ snapshots:
       '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/vfs@1.6.4(typescript@5.4.5)':
+  '@typescript/vfs@1.6.4(supports-color@5.5.0)(typescript@5.4.5)':
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.4.5
@@ -6766,6 +6859,12 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
@@ -7108,7 +7207,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.9:
+  engine.io@6.6.9(supports-color@5.5.0):
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 24.12.4
@@ -7237,49 +7336,49 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.4.1(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
 
-  eslint-plugin-erasable-syntax-only@0.4.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3):
+  eslint-plugin-erasable-syntax-only@0.4.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3)
       cached-factory: 0.2.0
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-promise@7.3.0(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-promise@7.3.0(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
-      eslint: 10.4.1(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
 
-  eslint-plugin-simple-import-sort@13.0.0(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-simple-import-sort@13.0.0(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
 
-  eslint-plugin-tsdoc@0.5.2(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3):
+  eslint-plugin-tsdoc@0.5.2(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
 
-  eslint-plugin-unicorn@70.0.0(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-unicorn@70.0.0(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       browserslist: 4.28.4
       change-case: 5.4.4
       ci-info: 4.4.0
       core-js-compat: 3.49.0
       detect-indent: 7.0.2
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       find-up-simple: 1.0.1
       globals: 17.7.0
       indent-string: 5.0.0
@@ -7290,11 +7389,11 @@ snapshots:
       semver: 7.8.5
       strip-indent: 4.1.1
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -7307,11 +7406,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.4.1(jiti@2.7.0):
+  eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@5.5.0)
       '@eslint/config-helpers': 0.6.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -7443,11 +7542,11 @@ snapshots:
 
   fastify-plugin@6.0.0: {}
 
-  fastify-socket.io@5.1.0(fastify@5.9.0)(socket.io@4.8.3):
+  fastify-socket.io@5.1.0(fastify@5.9.0)(socket.io@4.8.3(supports-color@5.5.0)):
     dependencies:
       fastify: 5.9.0
       fastify-plugin: 4.5.1
-      socket.io: 4.8.3
+      socket.io: 4.8.3(supports-color@5.5.0)
       tslib: 2.8.1
 
   fastify@5.9.0:
@@ -7671,7 +7770,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@9.1.0:
+  http-proxy-agent@9.1.0(supports-color@5.5.0):
     dependencies:
       agent-base: 9.0.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -7687,14 +7786,14 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@9.1.0:
+  https-proxy-agent@9.1.0(supports-color@5.5.0):
     dependencies:
       agent-base: 9.0.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -7749,17 +7848,17 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.11.1))(ioredis@5.11.1):
+  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.11.1))(ioredis@5.11.1(supports-color@5.5.0)):
     dependencies:
       '@ioredis/as-callback': 3.0.0
       '@ioredis/commands': 1.10.0
       '@types/ioredis-mock': 8.2.7(ioredis@5.11.1)
       fengari: 0.1.5
       fengari-interop: 0.1.4(fengari@0.1.5)
-      ioredis: 5.11.1
+      ioredis: 5.11.1(supports-color@5.5.0)
       semver: 7.8.5
 
-  ioredis@5.11.1:
+  ioredis@5.11.1(supports-color@5.5.0):
     dependencies:
       '@ioredis/commands': 1.10.0
       cluster-key-slot: 1.1.1
@@ -7879,7 +7978,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  json-schema-resolver@3.0.0:
+  json-schema-resolver@3.0.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       fast-uri: 3.1.2
@@ -8059,14 +8158,14 @@ snapshots:
 
   map-cache@0.2.2: {}
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@5.5.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@5.5.0)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -8234,7 +8333,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@5.5.0):
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@5.5.0)
@@ -8519,11 +8618,11 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-jsdoc@1.8.1(prettier@3.8.3):
+  prettier-plugin-jsdoc@1.8.1(prettier@3.8.3)(supports-color@5.5.0):
     dependencies:
       binary-searching: 2.0.5
       comment-parser: 1.4.7
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@5.5.0)
       prettier: 3.8.3
     transitivePeerDependencies:
       - supports-color
@@ -8551,6 +8650,12 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
 
   qlobber@8.0.1: {}
 
@@ -8606,7 +8711,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
@@ -8729,7 +8834,7 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socket.io-adapter@2.5.8:
+  socket.io-adapter@2.5.8(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       ws: 8.21.0
@@ -8738,28 +8843,28 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.6(supports-color@5.5.0):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.3:
+  socket.io@4.8.3(supports-color@5.5.0):
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
       debug: 4.4.3(supports-color@5.5.0)
-      engine.io: 6.6.9
-      socket.io-adapter: 2.5.8
-      socket.io-parser: 4.2.6
+      engine.io: 6.6.9(supports-color@5.5.0)
+      socket.io-adapter: 2.5.8(supports-color@5.5.0)
+      socket.io-parser: 4.2.6(supports-color@5.5.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socks-proxy-agent@10.1.0:
+  socks-proxy-agent@10.1.0(supports-color@5.5.0):
     dependencies:
       agent-base: 9.0.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -8923,13 +9028,13 @@ snapshots:
 
   typebox@1.3.2: {}
 
-  typescript-eslint@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3):
+  typescript-eslint@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.4.1(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0)(supports-color@5.5.0))(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color

--- a/routes/__snapshots__/index.test.ts.snap
+++ b/routes/__snapshots__/index.test.ts.snap
@@ -7578,6 +7578,8 @@ paths:
                         - signature
                       type: object
                     type:
+                      enum:
+                        - public-key
                       type: string
                   required:
                     - id

--- a/routes/__snapshots__/index.test.ts.snap
+++ b/routes/__snapshots__/index.test.ts.snap
@@ -7487,6 +7487,125 @@ paths:
       summary: 获取未读通知
       tags:
         - misc
+  /p1/passkey/login/options:
+    post:
+      description: |-
+
+        获取 WebAuthn authentication options。
+        不传 credentials 时（usernameless 模式），浏览器将展示系统账户选择器。
+      operationId: passkeyLoginOptions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                credentials:
+                  items:
+                    properties:
+                      credentialId:
+                        type: string
+                      transports:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - credentialId
+                    type: object
+                  type: array
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  challenge:
+                    type: string
+                  options: {}
+                  rpId:
+                    type: string
+                required:
+                  - options
+                  - challenge
+                  - rpId
+                type: object
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      summary: 获取 Passkey 登录选项
+      tags:
+        - misc
+  /p1/passkey/login/verify:
+    post:
+      operationId: passkeyLoginVerify
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                challenge:
+                  description: 之前 options 返回的 challenge
+                  type: string
+                credential:
+                  additionalProperties: true
+                  properties:
+                    clientExtensionResults:
+                      additionalProperties: true
+                      properties: {}
+                      type: object
+                    id:
+                      type: string
+                    rawId:
+                      type: string
+                    response:
+                      properties:
+                        authenticatorData:
+                          type: string
+                        clientDataJSON:
+                          type: string
+                        signature:
+                          type: string
+                        userHandle:
+                          type: string
+                      required:
+                        - clientDataJSON
+                        - authenticatorData
+                        - signature
+                      type: object
+                    type:
+                      type: string
+                  required:
+                    - id
+                    - rawId
+                    - type
+                    - response
+                    - clientExtensionResults
+                  type: object
+              required:
+                - challenge
+                - credential
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Default Response
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      summary: 验证 Passkey 登录并签发 session
+      tags:
+        - misc
   /p1/persons/-/comments/{commentID}:
     delete:
       operationId: deletePersonComment

--- a/routes/private/index.ts
+++ b/routes/private/index.ts
@@ -18,6 +18,7 @@ import * as episode from './routes/episode.ts';
 import * as group from './routes/group.ts';
 import * as index from './routes/index.ts';
 import * as misc from './routes/misc.ts';
+import * as passkey from './routes/passkey.ts';
 import * as person from './routes/person.ts';
 import * as privacy from './routes/privacy.ts';
 import * as friend from './routes/relationship.ts';
@@ -86,6 +87,7 @@ async function API(app: App) {
   await app.register(group.setup);
   await app.register(index.setup);
   await app.register(misc.setup);
+  await app.register(passkey.setup);
   await app.register(person.setup);
   await app.register(privacy.setup);
   await app.register(report.setup);

--- a/routes/private/routes/passkey.ts
+++ b/routes/private/routes/passkey.ts
@@ -1,0 +1,238 @@
+import { createError } from '@fastify/error';
+import httpCodes from 'http-status-codes';
+import t from 'typebox';
+
+import { db, op, schema } from '@app/drizzle';
+import * as session from '@app/lib/auth/session.ts';
+import { CookieKey } from '@app/lib/auth/session.ts';
+import config from '@app/lib/config.ts';
+import { avatar } from '@app/lib/images.ts';
+import { Tag } from '@app/lib/openapi/index.ts';
+import * as passkey from '@app/lib/passkey/index.ts';
+import { fetchPermission } from '@app/lib/user/perm.ts';
+import { createLimiter } from '@app/lib/utils/rate-limit/index.ts';
+import type { App } from '@app/routes/type.ts';
+
+const TooManyRequestsError = createError(
+  'TOO_MANY_REQUESTS',
+  'too many failed passkey login attempts',
+  httpCodes.TOO_MANY_REQUESTS,
+);
+
+const PasskeyLoginFailedError = createError<[]>(
+  'PASSKEY_LOGIN_FAILED',
+  'passkey login failed',
+  httpCodes.UNAUTHORIZED,
+);
+
+const PasskeyUnavailableError = createError<[]>(
+  'PASSKEY_UNAVAILABLE',
+  'passkey is not available',
+  httpCodes.SERVICE_UNAVAILABLE,
+);
+
+function parseList(value: string): string[] {
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function getRpIdConfig() {
+  return {
+    rpName: config.passkey.rpName,
+    rpIds: parseList(config.passkey.rpIds),
+    origins: parseList(config.passkey.origins),
+  };
+}
+
+function currentRpId(host: string, allowlist: string[]): string {
+  const normalizedHost = host.replace(/:\d+$/, '').toLowerCase();
+  for (const rpId of allowlist) {
+    if (
+      normalizedHost === rpId.toLowerCase() ||
+      normalizedHost.endsWith(`.${rpId.toLowerCase()}`)
+    ) {
+      return rpId;
+    }
+  }
+  return '';
+}
+
+function currentOrigin(host: string, protocol: string): string {
+  return `${protocol}://${host}`;
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function setup(app: App) {
+  const loginLimiter = createLimiter();
+
+  // Login options
+  app.post(
+    '/passkey/login/options',
+    {
+      schema: {
+        summary: '获取 Passkey 登录选项',
+        description: `
+获取 WebAuthn authentication options。
+不传 credentials 时（usernameless 模式），浏览器将展示系统账户选择器。`,
+        operationId: 'passkeyLoginOptions',
+        tags: [Tag.Misc],
+        body: t.Object({
+          credentials: t.Optional(
+            t.Array(
+              t.Object({
+                credentialId: t.String(),
+                transports: t.Optional(t.Array(t.String())),
+              }),
+            ),
+          ),
+        }),
+        response: {
+          200: t.Object({
+            options: t.Any(),
+            challenge: t.String(),
+            rpId: t.String(),
+          }),
+        },
+      },
+    },
+    async ({ body: { credentials }, headers, hostname, ip }) => {
+      const cfg = getRpIdConfig();
+      const rpId = currentRpId(hostname, cfg.rpIds);
+      if (!rpId) {
+        throw new PasskeyUnavailableError();
+      }
+
+      const { challenge } = await passkey.createChallenge({
+        uid: 0,
+        type: 'login',
+        rpId,
+        ip,
+        userAgent: headers['user-agent'] ?? '',
+      });
+
+      const { options } = await passkey.generatePasskeyAuthenticationOptions({
+        rpId,
+        challenge,
+        credentials,
+      });
+
+      return {
+        options,
+        challenge,
+        rpId,
+      };
+    },
+  );
+
+  // Login verify
+  app.post(
+    '/passkey/login/verify',
+    {
+      schema: {
+        summary: '验证 Passkey 登录并签发 session',
+        operationId: 'passkeyLoginVerify',
+        tags: [Tag.Misc],
+        body: t.Object({
+          challenge: t.String({ description: '之前 options 返回的 challenge' }),
+          credential: passkey.AuthenticationResponseSchema,
+        }),
+        response: {
+          200: t.Any(),
+        },
+      },
+    },
+    async (
+      { body: { challenge, credential: credentialResponse }, hostname, ip, protocol },
+      reply,
+    ) => {
+      const cfg = getRpIdConfig();
+      const rpId = currentRpId(hostname, cfg.rpIds);
+      if (!rpId) {
+        throw new PasskeyUnavailableError();
+      }
+
+      // Check login rate limit
+      const limitKey = `passkey-login-rate-limit-${ip}`;
+      const { remain, reset, limit, limited } = await loginLimiter.get(limitKey, 600, 10);
+      void reply.headers({
+        'X-RateLimit-Remaining': remain,
+        'X-RateLimit-Limit': limit,
+        'X-RateLimit-Reset': reset,
+      });
+      if (limited) {
+        throw new TooManyRequestsError();
+      }
+
+      // Consume challenge
+      const consumed = await passkey.consumeChallenge(challenge, 'login', rpId);
+      if (!consumed) {
+        throw new PasskeyLoginFailedError();
+      }
+
+      // Find the credential by ID from the authenticator response
+      const credential = await passkey.fetchCredentialByCredentialId(credentialResponse.id, rpId);
+      if (!credential) {
+        throw new PasskeyLoginFailedError();
+      }
+
+      const origin = currentOrigin(hostname, protocol);
+      const result = await passkey.verifyPasskeyAuthentication({
+        rpId,
+        origin,
+        expectedChallenge: challenge,
+        credential: {
+          credentialId: credential.credentialId,
+          publicKey: credential.publicKey,
+          counter: credential.signCount,
+          transports: credential.transports,
+          webauthnUserId: credential.webauthnUserId,
+        },
+        response: credentialResponse,
+      });
+
+      if (!result.verified || !result.userVerified) {
+        throw new PasskeyLoginFailedError();
+      }
+
+      // Fetch the user
+      const [user] = await db
+        .select()
+        .from(schema.chiiUsers)
+        .where(op.eq(schema.chiiUsers.id, credential.uid))
+        .limit(1);
+
+      if (!user) {
+        throw new PasskeyLoginFailedError();
+      }
+
+      // Check account status
+      const perms = await fetchPermission(user.groupid);
+      if (perms.user_ban || perms.ban_visit) {
+        throw new PasskeyLoginFailedError();
+      }
+
+      // Update credential counter and last used time
+      await passkey.markCredentialUsed(credential.id, result.newCounter);
+
+      // Reset login rate limit on success
+      await loginLimiter.reset(limitKey);
+
+      // Create session
+      const token = await session.create({
+        id: user.id,
+        regTime: user.regdate,
+      });
+
+      void reply.cookie(CookieKey, token, { maxAge: 24 * 60 * 60 * 30 });
+
+      return {
+        ...user,
+        group: user.groupid,
+        avatar: avatar(user.avatar),
+        joinedAt: user.regdate,
+      };
+    },
+  );
+}

--- a/routes/private/routes/passkey.ts
+++ b/routes/private/routes/passkey.ts
@@ -59,7 +59,21 @@ function currentRpId(host: string, allowlist: string[]): string {
   return '';
 }
 
-function currentOrigin(host: string, protocol: string): string {
+function currentOrigin(host: string, origins: string[], protocol: string): string {
+  const normalizedHost = host.replace(/:\d+$/, '').toLowerCase();
+  for (const origin of origins) {
+    try {
+      const url = new URL(origin);
+      if (
+        url.hostname.toLowerCase() === normalizedHost ||
+        normalizedHost.endsWith(`.${url.hostname.toLowerCase()}`)
+      ) {
+        return origin;
+      }
+    } catch {
+      continue;
+    }
+  }
   return `${protocol}://${host}`;
 }
 
@@ -104,7 +118,13 @@ export async function setup(app: App) {
         throw new PasskeyUnavailableError();
       }
 
-      const { challenge } = await passkey.createChallenge({
+      const { options } = await passkey.generatePasskeyAuthenticationOptions({
+        rpId,
+        credentials,
+      });
+
+      await passkey.createChallenge({
+        challenge: options.challenge,
         uid: 0,
         type: 'login',
         rpId,
@@ -112,15 +132,9 @@ export async function setup(app: App) {
         userAgent: headers['user-agent'] ?? '',
       });
 
-      const { options } = await passkey.generatePasskeyAuthenticationOptions({
-        rpId,
-        challenge,
-        credentials,
-      });
-
       return {
         options,
-        challenge,
+        challenge: options.challenge,
         rpId,
       };
     },
@@ -177,20 +191,26 @@ export async function setup(app: App) {
         throw new PasskeyLoginFailedError();
       }
 
-      const origin = currentOrigin(hostname, protocol);
-      const result = await passkey.verifyPasskeyAuthentication({
-        rpId,
-        origin,
-        expectedChallenge: challenge,
-        credential: {
-          credentialId: credential.credentialId,
-          publicKey: credential.publicKey,
-          counter: credential.signCount,
-          transports: credential.transports,
-          webauthnUserId: credential.webauthnUserId,
-        },
-        response: credentialResponse,
-      });
+      const origin = currentOrigin(hostname, cfg.origins, protocol);
+
+      let result: Awaited<ReturnType<typeof passkey.verifyPasskeyAuthentication>>;
+      try {
+        result = await passkey.verifyPasskeyAuthentication({
+          rpId,
+          origin,
+          expectedChallenge: challenge,
+          credential: {
+            credentialId: credential.credentialId,
+            publicKey: credential.publicKey,
+            counter: credential.signCount,
+            transports: credential.transports,
+            webauthnUserId: credential.webauthnUserId,
+          },
+          response: credentialResponse,
+        });
+      } catch {
+        throw new PasskeyLoginFailedError();
+      }
 
       if (!result.verified || !result.userVerified) {
         throw new PasskeyLoginFailedError();
@@ -228,9 +248,12 @@ export async function setup(app: App) {
       void reply.cookie(CookieKey, token, { maxAge: 24 * 60 * 60 * 30 });
 
       return {
-        ...user,
-        group: user.groupid,
+        id: user.id,
+        username: user.username,
+        nickname: user.nickname,
         avatar: avatar(user.avatar),
+        sign: user.sign,
+        group: user.groupid,
         joinedAt: user.regdate,
       };
     },

--- a/routes/private/routes/passkey.ts
+++ b/routes/private/routes/passkey.ts
@@ -63,17 +63,14 @@ function currentOrigin(host: string, origins: string[], protocol: string): strin
   const normalizedHost = host.replace(/:\d+$/, '').toLowerCase();
   for (const origin of origins) {
     try {
-      const url = new URL(origin);
-      if (
-        url.hostname.toLowerCase() === normalizedHost ||
-        normalizedHost.endsWith(`.${url.hostname.toLowerCase()}`)
-      ) {
+      if (new URL(origin).hostname.toLowerCase() === normalizedHost) {
         return origin;
       }
     } catch {
       continue;
     }
   }
+  // fallback: use request protocol (http in dev, https in prod)
   return `${protocol}://${host}`;
 }
 

--- a/routes/private/routes/passkey.ts
+++ b/routes/private/routes/passkey.ts
@@ -74,9 +74,12 @@ function currentOrigin(host: string, origins: string[], protocol: string): strin
   return `${protocol}://${host}`;
 }
 
+const passkeyLoginRateLimitWindow = 600; // 10 minutes
+const passkeyLoginRateLimitMax = 10;
+
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function setup(app: App) {
-  const loginLimiter = createLimiter();
+  const limiter = createLimiter();
 
   // Login options
   app.post(
@@ -108,7 +111,22 @@ export async function setup(app: App) {
         },
       },
     },
-    async ({ body: { credentials }, headers, hostname, ip }) => {
+    async ({ body: { credentials }, headers, hostname, ip }, reply) => {
+      // Rate limit: prevent flooding Redis with challenge keys
+      const limitKey = `passkey-options-rate-limit-${ip}`;
+      const { remain, reset, limit, limited } = await limiter.get(
+        limitKey,
+        passkeyLoginRateLimitWindow,
+        passkeyLoginRateLimitMax,
+      );
+      void reply.headers({
+        'X-RateLimit-Remaining': remain,
+        'X-RateLimit-Limit': limit,
+        'X-RateLimit-Reset': reset,
+      });
+      if (limited) {
+        throw new TooManyRequestsError();
+      }
       const cfg = getRpIdConfig();
       const rpId = currentRpId(hostname, cfg.rpIds);
       if (!rpId) {
@@ -166,7 +184,11 @@ export async function setup(app: App) {
 
       // Check login rate limit
       const limitKey = `passkey-login-rate-limit-${ip}`;
-      const { remain, reset, limit, limited } = await loginLimiter.get(limitKey, 600, 10);
+      const { remain, reset, limit, limited } = await limiter.get(
+        limitKey,
+        passkeyLoginRateLimitWindow,
+        passkeyLoginRateLimitMax,
+      );
       void reply.headers({
         'X-RateLimit-Remaining': remain,
         'X-RateLimit-Limit': limit,
@@ -234,7 +256,7 @@ export async function setup(app: App) {
       await passkey.markCredentialUsed(credential.id, result.newCounter);
 
       // Reset login rate limit on success
-      await loginLimiter.reset(limitKey);
+      await limiter.reset(limitKey);
 
       // Create session
       const token = await session.create({

--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -42,12 +42,24 @@
         ></div>
       </div>
       <button type='submit' class='btn btn-primary'>Submit</button>
+      <button
+        type='button'
+        class='btn btn-outline-secondary ms-2'
+        id='passkey-login-btn'
+        style='display:none'
+      >
+        使用 Passkey 登录
+      </button>
     </form>
   </div>
 </div>
 
 <script>
   $(document).ready(function () {
+    if (window.PublicKeyCredential) {
+      $('#passkey-login-btn').show();
+    }
+
     $('form').on('submit', function (e) {
       e.preventDefault();
       $('.error-details').html('');
@@ -99,6 +111,67 @@
 
       submit();
     });
+
+    $('#passkey-login-btn').on('click', async function () {
+      $('.error-details').html('');
+
+      try {
+        // 1. Get authentication options
+        const optionsRes = await fetch('/p1/passkey/login/options', {
+          method: 'post',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+
+        if (!optionsRes.ok) {
+          const err = await optionsRes.json();
+          showError(err.message || '获取 Passkey 选项失败');
+          return;
+        }
+
+        const { options, challenge } = await optionsRes.json();
+
+        // 2. Prompt user to authenticate with their passkey
+        let credential;
+        try {
+          credential = await navigator.credentials.get({
+            publicKey: options,
+            mediation: 'required',
+          });
+        } catch (_err) {
+          // User cancelled or no passkey available — not an error
+          return;
+        }
+
+        // 3. Verify with server
+        const verifyRes = await fetch('/p1/passkey/login/verify', {
+          method: 'post',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ challenge, credential }),
+        });
+
+        if (!verifyRes.ok) {
+          const err = await verifyRes.json();
+          showError(err.message || 'Passkey 登录失败，请稍后再试。');
+          return;
+        }
+
+        await verifyRes.json();
+
+        let qs = new URLSearchParams(location.search);
+        const to = qs.get('backTo') ?? '/demo/';
+        location.href = to.startsWith('/') ? to : '/demo/';
+      } catch (err) {
+        showError('Passkey 登录失败，请稍后再试。');
+        console.error(err);
+      }
+    });
   });
+
+  function showError(msg) {
+    $('.error-details').append(
+      `<li class="m-1 list-group-item list-group-item-danger">${msg}</li>`,
+    );
+  }
 </script>
 {% endblock %}

--- a/templates/login.liquid
+++ b/templates/login.liquid
@@ -3,6 +3,9 @@
 
 {% block head %}
 <script src='https://challenges.cloudflare.com/turnstile/v0/api.js' async defer></script>
+<script
+  src='https://cdn.jsdelivr.net/npm/@simplewebauthn/browser@13/dist/bundle/index.umd.min.js'
+></script>
 {% endblock %}
 
 {% block content %}
@@ -134,10 +137,7 @@
         // 2. Prompt user to authenticate with their passkey
         let credential;
         try {
-          credential = await navigator.credentials.get({
-            publicKey: options,
-            mediation: 'required',
-          });
+          credential = await SimpleWebAuthnBrowser.startAuthentication({ optionsJSON: options });
         } catch (_err) {
           // User cancelled or no passkey available — not an error
           return;


### PR DESCRIPTION
## Summary

Add passkey (WebAuthn) login support, following the architecture from [Bangumi PR#47](https://github.com/Sai/Bangumi/pull/47).

### Changes

- **Database**: Add `chii_passkey_credentials` table to drizzle schema
- **Config**: Add `passkey` section (rpName, rpIds, origins) to config.yaml schema
- **WebAuthn**: Implement authentication using `@simplewebauthn/server`
- **Challenges**: Redis-based with TTL and one-time consumption
- **Validation**: TypeBox runtime validation for Redis payloads and client responses
- **Rate limiting**: 10 attempts per 10 minutes per IP

### API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | /p1/passkey/login/options | Get WebAuthn authentication options (usernameless) |
| POST | /p1/passkey/login/verify | Verify authentication response and create session |

### Demo

- Added passkey login button to `/demo/login` page
- Button only shown when browser supports WebAuthn