### PR TITLE
fix(wiki): accept recent since as query

### DIFF
--- a/routes/__snapshots__/index.test.ts.snap
+++ b/routes/__snapshots__/index.test.ts.snap
@@ -12578,9 +12578,9 @@ paths:
             unix time stamp, only return last update time >= since
 
             only allow recent 2 days
-          in: path
+          in: query
           name: since
-          required: true
+          required: false
           schema:
             default: 0
             type: integer
@@ -12624,9 +12624,9 @@ paths:
             unix time stamp, only return last update time >= since
 
             only allow recent 2 days
-          in: path
+          in: query
           name: since
-          required: true
+          required: false
           schema:
             default: 0
             type: integer
@@ -12670,9 +12670,9 @@ paths:
             unix time stamp, only return last update time >= since
 
             only allow recent 2 days
-          in: path
+          in: query
           name: since
-          required: true
+          required: false
           schema:
             default: 0
             type: integer
@@ -12716,9 +12716,9 @@ paths:
             unix time stamp, only return last update time >= since
 
             only allow recent 2 days
-          in: path
+          in: query
           name: since
-          required: true
+          required: false
           schema:
             default: 0
             type: integer

--- a/routes/__snapshots__/index.test.ts.snap
+++ b/routes/__snapshots__/index.test.ts.snap
@@ -11971,12 +11971,27 @@ paths:
                 properties: {}
                 type: object
           description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
       tags:
         - wiki
   /p1/wiki/persons:
@@ -13419,6 +13434,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: default error response type
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '403':
           content:
             application/json:
@@ -13431,6 +13452,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
       tags:
         - wiki
   /p1/wiki/subjects/{subjectID}/covers/{imageID}/vote:
@@ -13458,12 +13482,27 @@ paths:
                 properties: {}
                 type: object
           description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
       summary: 撤消条目封面投票
       tags:
         - wiki
@@ -13491,12 +13530,27 @@ paths:
                 properties: {}
                 type: object
           description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
       summary: 为条目封面投票
       tags:
         - wiki
@@ -13870,12 +13924,27 @@ paths:
                 properties: {}
                 type: object
           description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
           description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
       tags:
         - wiki
   /p1/wiki/users/{username}/contributions/characters:

--- a/routes/private/routes/wiki/index.test.ts
+++ b/routes/private/routes/wiki/index.test.ts
@@ -11,3 +11,21 @@ test('test recent change list', async () => {
 
   expect(res.statusCode).toBe(200);
 });
+
+test.each([
+  ['/recent/subjects', { subject: [], persons: [] }],
+  ['/recent/persons', []],
+  ['/recent/characters', []],
+  ['/recent/episodes', []],
+])('filters recent change list by since query for %s', async (url, expected) => {
+  const app = createTestServer();
+  await app.register(setup);
+
+  const res = await app.inject({
+    url,
+    query: { since: String(Math.ceil(Date.now() / 1000) + 3600) },
+  });
+
+  expect(res.statusCode).toBe(200);
+  expect(res.json()).toEqual(expected);
+});

--- a/routes/private/routes/wiki/index.ts
+++ b/routes/private/routes/wiki/index.ts
@@ -32,12 +32,14 @@ export async function setupRecentChangeList(app: App) {
 
   const RecentItem = t.Array(t.Object({ id: t.Integer(), createdAt: t.Integer() }));
 
-  const sinceParam = t.Object({
-    since: t.Integer({
-      default: 0,
-      description:
-        'unix time stamp, only return last update time >= since\n\nonly allow recent 2 days',
-    }),
+  const sinceQuery = t.Object({
+    since: t.Optional(
+      t.Integer({
+        default: 0,
+        description:
+          'unix time stamp, only return last update time >= since\n\nonly allow recent 2 days',
+      }),
+    ),
   });
 
   app.addSchema(RecentWikiChange);
@@ -49,20 +51,14 @@ export async function setupRecentChangeList(app: App) {
         tags: [Tag.Wiki],
         operationId: 'getRecentSubjectWiki',
         description: '获取最近两天的wiki更新',
-        params: t.Object({
-          since: t.Integer({
-            default: 0,
-            description:
-              'unix time stamp, only return last update time >= since\n\nonly allow recent 2 days',
-          }),
-        }),
+        querystring: sinceQuery,
         response: {
           200: res.Ref(RecentWikiChange),
           401: res.Ref(res.Error),
         },
       },
     },
-    async ({ params: { since } }): Promise<Static<typeof RecentWikiChange>> => {
+    async ({ query: { since = 0 } }): Promise<Static<typeof RecentWikiChange>> => {
       since = Math.max(Date.now() / 1000 - 3600 * 24 * 2, since);
 
       const subjects = await db
@@ -110,14 +106,14 @@ export async function setupRecentChangeList(app: App) {
         tags: [Tag.Wiki],
         operationId: 'getRecentPersonWiki',
         description: '获取最近两天的人物wiki更新',
-        params: sinceParam,
+        querystring: sinceQuery,
         response: {
           200: RecentItem,
           401: res.Ref(res.Error),
         },
       },
     },
-    async ({ params: { since } }): Promise<Static<typeof RecentItem>> => {
+    async ({ query: { since = 0 } }): Promise<Static<typeof RecentItem>> => {
       since = Math.max(Date.now() / 1000 - 3600 * 24 * 2, since);
 
       const persons = await db
@@ -151,14 +147,14 @@ export async function setupRecentChangeList(app: App) {
         tags: [Tag.Wiki],
         operationId: 'getRecentCharacterWiki',
         description: '获取最近两天的角色wiki更新',
-        params: sinceParam,
+        querystring: sinceQuery,
         response: {
           200: RecentItem,
           401: res.Ref(res.Error),
         },
       },
     },
-    async ({ params: { since } }): Promise<Static<typeof RecentItem>> => {
+    async ({ query: { since = 0 } }): Promise<Static<typeof RecentItem>> => {
       since = Math.max(Date.now() / 1000 - 3600 * 24 * 2, since);
 
       const characters = await db
@@ -192,14 +188,14 @@ export async function setupRecentChangeList(app: App) {
         tags: [Tag.Wiki],
         operationId: 'getRecentEpisodeWiki',
         description: '获取最近两天的章节wiki更新',
-        params: sinceParam,
+        querystring: sinceQuery,
         response: {
           200: RecentItem,
           401: res.Ref(res.Error),
         },
       },
     },
-    async ({ params: { since } }): Promise<Static<typeof RecentItem>> => {
+    async ({ query: { since = 0 } }): Promise<Static<typeof RecentItem>> => {
       since = Math.max(Date.now() / 1000 - 3600 * 24 * 2, since);
 
       const episodes = await db

--- a/routes/private/routes/wiki/subject/image.ts
+++ b/routes/private/routes/wiki/subject/image.ts
@@ -16,7 +16,7 @@ import {
   uploadSubjectImage,
 } from '@app/lib/image/index.ts';
 import { LikeType } from '@app/lib/like.ts';
-import { Tag } from '@app/lib/openapi/index.ts';
+import { Security, Tag } from '@app/lib/openapi/index.ts';
 import imaginary from '@app/lib/services/imaginary.ts';
 import * as Subject from '@app/lib/subject/index.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
@@ -161,8 +161,10 @@ export function setup(app: App) {
         params: t.Object({
           subjectID: t.Integer(),
         }),
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
         response: {
           200: t.Object({}),
+          401: res.Ref(res.Error),
           ...res.errorResponses(
             ImageFileTooLarge(),
             UnsupportedImageFormat(),
@@ -247,8 +249,11 @@ export function setup(app: App) {
           subjectID: t.Integer({ minimum: 1 }),
           imageID: t.Integer({ minimum: 1 }),
         }),
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
         response: {
           200: t.Object({}),
+          401: res.Ref(res.Error),
+          403: res.Ref(res.Error),
         },
       },
       preHandler: [
@@ -299,8 +304,11 @@ export function setup(app: App) {
           subjectID: t.Integer({ minimum: 1 }),
           imageID: t.Integer({ minimum: 1 }),
         }),
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
         response: {
           200: t.Object({}),
+          401: res.Ref(res.Error),
+          403: res.Ref(res.Error),
         },
       },
       preHandler: [

--- a/routes/private/routes/wiki/subject/mgr.ts
+++ b/routes/private/routes/wiki/subject/mgr.ts
@@ -3,8 +3,9 @@ import t from 'typebox';
 
 import { db, op, schema } from '@app/drizzle';
 import { NotAllowedError } from '@app/lib/auth/index.ts';
-import { Tag } from '@app/lib/openapi/index.ts';
+import { Security, Tag } from '@app/lib/openapi/index.ts';
 import { RevType } from '@app/lib/rev/type.ts';
+import * as res from '@app/lib/types/res.ts';
 import { LimitAction } from '@app/lib/utils/rate-limit';
 import { requireLogin } from '@app/routes/hooks/pre-handler.ts';
 import { rateLimit } from '@app/routes/hooks/rate-limit';
@@ -21,11 +22,14 @@ export function setup(app: App) {
           subjectID: t.Integer({ examples: [184017] }),
           reason: t.String(),
         }),
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
         response: {
           200: t.Object({}),
+          401: res.Ref(res.Error),
+          403: res.Ref(res.Error),
         },
       },
-      preHandler: [requireLogin('list subject covers')],
+      preHandler: [requireLogin('lock a subject')],
     },
     async ({ body, auth }) => {
       if (!auth.permission.subject_lock) {
@@ -70,11 +74,14 @@ export function setup(app: App) {
           subjectID: t.Integer({ examples: [184017] }),
           reason: t.String(),
         }),
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
         response: {
           200: t.Object({}),
+          401: res.Ref(res.Error),
+          403: res.Ref(res.Error),
         },
       },
-      preHandler: [requireLogin('list subject covers')],
+      preHandler: [requireLogin('unlock a subject')],
     },
     async ({ body, auth }) => {
       if (!auth.permission.subject_lock) {


### PR DESCRIPTION
## Summary

- Treat Wiki recent `since` filters as optional query parameters for subject, person, character, and episode recent endpoints.
- Read `since` from `query` in the handlers so runtime filtering matches the fixed route paths.
- Declare cookie/bearer security and 401/403 responses for protected Wiki write operations covering subject lock/unlock and subject cover upload/vote/unvote endpoints.
- Add focused coverage for query-based recent filtering and update the OpenAPI snapshot.

## Validation

- `pnpm exec prettier --check routes/private/routes/wiki/index.ts routes/private/routes/wiki/index.test.ts`
- `pnpm exec eslint -c eslint.config.mjs routes/private/routes/wiki/index.ts routes/private/routes/wiki/index.test.ts`
- `pnpm exec prettier --check routes/private/routes/wiki/subject/mgr.ts routes/private/routes/wiki/subject/image.ts`
- `pnpm exec eslint -c eslint.config.mjs routes/private/routes/wiki/subject/mgr.ts routes/private/routes/wiki/subject/image.ts`
- `pnpm exec tsc`
- `pnpm build`
- Minimal OpenAPI generation check confirmed all four recent endpoints expose `since` as a non-required query parameter.
- Minimal OpenAPI generation check confirmed subject lock/unlock and subject cover upload/vote/unvote operations expose cookie/bearer security plus 401/403 responses.

Focused Vitest route tests could not complete locally because the required test database/Redis services were unavailable.
