### PR TITLE
fix: increase wiki rate limit

### DIFF
--- a/lib/utils/rate-limit/index.ts
+++ b/lib/utils/rate-limit/index.ts
@@ -112,9 +112,9 @@ export const LimitAction = Object.freeze({
   /**
    * 创建或更新 Wiki 内容
    *
-   * 5 分钟 10 次
+   * 5 分钟 30 次
    */
-  Wiki: { action: 'wiki', limit: 10, durationMinutes: 5 },
+  Wiki: { action: 'wiki', limit: 30, durationMinutes: 5 },
 } as const satisfies Record<string, LimitRule>);
 
 export interface Result {


### PR DESCRIPTION
将 Wiki 创建/更新限流从 5 分钟 10 次调整为 5 分钟 30 次。