### PR TITLE
fix: default missing vols_total in legacy timeline memo

### DIFF
--- a/lib/timeline/item.ts
+++ b/lib/timeline/item.ts
@@ -159,9 +159,10 @@ export async function parseTimelineMemo(
         return {
           progress: {
             batch: {
-              epsTotal: info.eps_total,
+              // 旧数据（PHP 时代）可能缺少 eps_total / vols_total 字段
+              epsTotal: info.eps_total ?? '??',
               epsUpdate: info.eps_update,
-              volsTotal: info.vols_total,
+              volsTotal: info.vols_total ?? '??',
               volsUpdate: info.vols_update,
               subject,
             },


### PR DESCRIPTION
## Problem

`GET /users/:username/timeline` returns 500 with `"volsTotal" is required!` from fast-json-stringify when a legacy timeline record (written by the old PHP backend) has a progress memo missing the `vols_total` field.

The memo is parsed by `parseTimelineMemo` in `lib/timeline/item.ts`, which passed `info.vols_total` through directly, producing `undefined`. Since `volsTotal` is required in the response schema (`lib/types/res.ts`), serialization fails and the whole request 500s for every client visiting that user's timeline.

## Fix

Default missing `eps_total` / `vols_total` to `'??'` (the same placeholder the writer uses for unknown counts, see `lib/timeline/writer.ts`), consistent with the existing legacy-data compatibility fixes (e.g. #0e30d049 for group).