### PR TITLE
fix(passkey): trust X-Forwarded-Proto for origin validation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,9 +26,11 @@ turnstile:
   siteKey: '1x00000000000000000000AA' # TURNSTILE_SITE_KEY
 
 passkey:
-  rpName: 'Bangumi'
-  rpIds: 'bgm.tv,bangumi.tv,chii.in'
-  origins: 'https://bgm.tv,https://bangumi.tv,https://chii.in'
+  rpName: 'Bangumi' # PASSKEY_RP_NAME
+  rpIds: 'bgm.tv,bangumi.tv,chii.in' # PASSKEY_RP_IDS
+  # 新部署域名需要追加对应 origin，例如 next 环境：
+  #   origins: 'https://bgm.tv,https://bangumi.tv,https://chii.in,https://next.bgm.tv'
+  origins: 'https://bgm.tv,https://bangumi.tv,https://chii.in' # PASSKEY_ORIGINS
 
 sentryDSN: 'https://examplePublicKey@o0.ingest.sentry.io/0' # SENTRY_DSN
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -152,9 +152,12 @@ export const schema = Obj({
   sentryDSN: t.Optional(t.String({ env: 'SENTRY_DSN' })),
 
   passkey: Obj({
-    rpName: t.String({ default: 'Bangumi' }),
-    rpIds: t.String({ default: 'bgm.tv,bangumi.tv,chii.in' }),
-    origins: t.String({ default: 'https://bgm.tv,https://bangumi.tv,https://chii.in' }),
+    rpName: t.String({ default: 'Bangumi', env: 'PASSKEY_RP_NAME' }),
+    rpIds: t.String({ default: 'bgm.tv,bangumi.tv,chii.in', env: 'PASSKEY_RP_IDS' }),
+    origins: t.String({
+      default: 'https://bgm.tv,https://bangumi.tv,https://chii.in',
+      env: 'PASSKEY_ORIGINS',
+    }),
   }),
 
   mysql: Obj({

--- a/routes/private/routes/passkey.test.ts
+++ b/routes/private/routes/passkey.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+
+import { currentOrigin } from './passkey.ts';
+
+const bgmOrigins = ['https://bgm.tv', 'https://bangumi.tv', 'https://chii.in'];
+
+describe('currentOrigin', () => {
+  test('returns the allowlisted origin when the host matches', () => {
+    expect(currentOrigin('bgm.tv', bgmOrigins, 'http')).toBe('https://bgm.tv');
+    expect(currentOrigin('next.bgm.tv', [...bgmOrigins, 'https://next.bgm.tv'], 'http')).toBe(
+      'https://next.bgm.tv',
+    );
+  });
+
+  test('host comparison ignores port and case', () => {
+    expect(currentOrigin('NEXT.BGM.TV:8080', [...bgmOrigins, 'https://next.bgm.tv'], 'http')).toBe(
+      'https://next.bgm.tv',
+    );
+  });
+
+  test('skips invalid allowlisted origins', () => {
+    expect(currentOrigin('bgm.tv', ['not a url', 'https://bgm.tv'], 'http')).toBe('https://bgm.tv');
+  });
+
+  test('falls back to the request protocol without X-Forwarded-Proto', () => {
+    // eslint-disable-next-line unicorn/prefer-https -- intentionally asserts the http fallback
+    expect(currentOrigin('next.bgm.tv', bgmOrigins, 'http')).toBe('http://next.bgm.tv');
+    expect(currentOrigin('next.bgm.tv', bgmOrigins, 'https')).toBe('https://next.bgm.tv');
+  });
+
+  test('uses X-Forwarded-Proto when present', () => {
+    expect(currentOrigin('next.bgm.tv', bgmOrigins, 'http', 'https')).toBe('https://next.bgm.tv');
+  });
+
+  test('X-Forwarded-Proto takes the first value when chained', () => {
+    expect(currentOrigin('next.bgm.tv', bgmOrigins, 'http', 'https, http')).toBe(
+      'https://next.bgm.tv',
+    );
+  });
+});

--- a/routes/private/routes/passkey.ts
+++ b/routes/private/routes/passkey.ts
@@ -59,7 +59,12 @@ function currentRpId(host: string, allowlist: string[]): string {
   return '';
 }
 
-function currentOrigin(host: string, origins: string[], protocol: string): string {
+export function currentOrigin(
+  host: string,
+  origins: string[],
+  protocol: string,
+  forwardedProto?: string,
+): string {
   const normalizedHost = host.replace(/:\d+$/, '').toLowerCase();
   for (const origin of origins) {
     try {
@@ -70,8 +75,10 @@ function currentOrigin(host: string, origins: string[], protocol: string): strin
       continue;
     }
   }
-  // fallback: use request protocol (http in dev, https in prod)
-  return `${protocol}://${host}`;
+  // fallback: when TLS terminates at a reverse proxy, request.protocol reflects
+  // the plaintext connection inside the proxy; prefer X-Forwarded-Proto instead
+  const effectiveProtocol = forwardedProto?.split(',', 1)[0]?.trim().toLowerCase() || protocol;
+  return `${effectiveProtocol}://${host}`;
 }
 
 const passkeyLoginRateLimitWindow = 600; // 10 minutes
@@ -173,7 +180,7 @@ export async function setup(app: App) {
       },
     },
     async (
-      { body: { challenge, credential: credentialResponse }, hostname, ip, protocol },
+      { body: { challenge, credential: credentialResponse }, headers, hostname, ip, protocol },
       reply,
     ) => {
       const cfg = getRpIdConfig();
@@ -210,7 +217,13 @@ export async function setup(app: App) {
         throw new PasskeyLoginFailedError();
       }
 
-      const origin = currentOrigin(hostname, cfg.origins, protocol);
+      const forwardedProto = headers['x-forwarded-proto'];
+      const origin = currentOrigin(
+        hostname,
+        cfg.origins,
+        protocol,
+        Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto,
+      );
 
       let result: Awaited<ReturnType<typeof passkey.verifyPasskeyAuthentication>>;
       try {


### PR DESCRIPTION
## Problem

Passkey (WebAuthn) login always fails with `401 PASSKEY_LOGIN_FAILED` on
domains served behind a TLS-terminating reverse proxy (e.g. `next.bgm.tv`),
regardless of user action.

Root cause: the expected origin was computed as `http://<host>`. When the
host is not in the `passkey.origins` allowlist, `currentOrigin` fell back to
`request.protocol`, which reflects the plaintext connection *inside* the
proxy (Fastify only inspects the socket; `trustProxy` is not configured).
The browser's real origin is `https://<host>`, and `@simplewebauthn/server`
does an exact string match on origin, so verification always threw and was
caught as `PASSKEY_LOGIN_FAILED`.

`rpId` was verified correct — `next.bgm.tv` suffix-matches the registered
`bgm.tv` credential, and `authenticatorData.rpIdHash` matches the credential.

## Changes

- `currentOrigin` now prefers `X-Forwarded-Proto` (first value) over
  `request.protocol` when falling back from the allowlist, so the expected
  origin becomes `https://<host>` behind a reverse proxy. Allowlist matching
  is unchanged and still takes precedence.
- Add `PASSKEY_RP_NAME` / `PASSKEY_RP_IDS` / `PASSKEY_ORIGINS` env
  overrides so deployments can extend the origins allowlist (e.g. append
  `https://next.bgm.tv`) without code changes.
- Document the `next.bgm.tv` override in `config.example.yaml`.
- Unit tests covering allowlist match, port/case normalization, invalid
  entries, and both fallback paths.

## Testing

- `pnpm tsc` — passed
- ESLint on changed files — passed
- `vitest routes/private/routes/passkey.test.ts` — 6/6 passed
