### PR TITLE
feat(api): add private message APIs

### DIFF
--- a/bin/main.ts
+++ b/bin/main.ts
@@ -40,7 +40,7 @@ async function main() {
   server.addHook('onReady', async () => {
     await Promise.all([
       producer.initialize(),
-      Subscriber.psubscribe(`event-user-notify-*`),
+      Subscriber.psubscribe(`event-user-notify-*`, `event-user-pm-*`),
       initTimelineSubscriber(),
     ]);
   });

--- a/docs/pm.md
+++ b/docs/pm.md
@@ -1,0 +1,202 @@
+# PM API 修改提案
+
+本文档列出 PM（私信）接口从新前端（React + SWR + 中文 UI）消费角度发现的需要修改的地方，
+供评审与实施。当前实现位于：
+
+- `routes/private/routes/pm.ts`
+- `lib/pm/utils.ts`
+- `lib/pm/type.ts`
+- `lib/types/req.ts` / `lib/types/res.ts`
+
+---
+
+## 1. 为 PM 引入领域化稳定错误码（高优先级）
+
+### 现状
+
+错误响应结构已是 `{ code, error, message, statusCode }`，但 PM 目前只用通用码，
+前端无法只靠 `code` 区分失败场景，只能匹配英文 `message`：
+
+| 场景                  | 当前 code            | 当前 message                                         |
+| --------------------- | -------------------- | ---------------------------------------------------- |
+| 被 ban_post 禁止发信  | `NOT_ALLOWED`        | `you don't have permission to send private message`  |
+| 标题/正文含不可见字符 | `BAD_REQUEST`        | `title/content contains invalid invisible character` |
+| 收件人超 10 个        | `BAD_REQUEST`        | `at most 10 receivers`                               |
+| 收件人不存在          | `NOT_FOUND`          | `user xxx not found`                                 |
+| 发给自己              | `BAD_REQUEST`        | `cannot send private message to yourself`            |
+| 被拉黑 / 隐私拒绝     | `NOT_ALLOWED`        | `send private message to this user`                  |
+| 回复时会话不存在      | `NOT_FOUND`          | `conversation xxx not found`                         |
+| 回复非本会话参与者    | `NOT_ALLOWED`        | `reply to this conversation`                         |
+| 读/删时消息不存在     | `NOT_FOUND`          | `private message xxx not found`                      |
+| 字段长度校验          | `FST_ERR_VALIDATION` | TypeBox 校验文本                                     |
+
+### 问题
+
+中文 UI 无法只靠 `code` 给用户准确提示，依赖英文 `message` 字符串匹配是脆弱的。
+
+### 建议
+
+每个预期失败模式一个稳定 `code`，前端做 `code → 中文文案` 映射，`message` 仅作兜底。
+建议新增 `lib/pm/errors.ts`：
+
+```ts
+import { createError } from '@fastify/error';
+import { StatusCodes } from 'http-status-codes';
+
+/** 发件人自身被 ban_post 禁止（账户级，与收件人无关） */
+export const PmSendBannedError = createError<[]>(
+  'PM_SEND_BANNED',
+  'you are not allowed to send private message',
+  StatusCodes.FORBIDDEN,
+);
+
+/** 收件人侧拒绝：被拉黑 / 隐私 none / 隐私 friends（故意合并，保护隐私） */
+export const PmSendNotAllowedError = createError<[]>(
+  'PM_SEND_NOT_ALLOWED',
+  'cannot send private message to this user',
+  StatusCodes.FORBIDDEN,
+);
+
+export const PmReceiverNotFoundError = createError<[string]>(
+  'PM_RECEIVER_NOT_FOUND',
+  'user %s not found',
+  StatusCodes.NOT_FOUND,
+);
+
+export const PmSendSelfError = createError<[]>(
+  'PM_SEND_SELF',
+  'cannot send private message to yourself',
+  StatusCodes.BAD_REQUEST,
+);
+
+export const PmTooManyReceiversError = createError<[]>(
+  'PM_TOO_MANY_RECEIVERS',
+  'at most 10 receivers',
+  StatusCodes.BAD_REQUEST,
+);
+
+export const PmContentInvalidError = createError<[string]>(
+  'PM_CONTENT_INVALID',
+  '%s contains invalid invisible character',
+  StatusCodes.BAD_REQUEST,
+);
+
+/** 会话/消息不存在，或当前用户无权访问（故意合并为 404，避免探测） */
+export const PmConversationNotFoundError = createError<[string]>(
+  'PM_CONVERSATION_NOT_FOUND',
+  'private message %s not found',
+  StatusCodes.NOT_FOUND,
+);
+```
+
+替换对照：
+
+| code                        | HTTP | 场景                              | 前端中文文案             |
+| --------------------------- | ---- | --------------------------------- | ------------------------ |
+| `PM_SEND_BANNED`            | 403  | 发件人被 ban_post 禁止            | 你当前无法发送私信       |
+| `PM_SEND_NOT_ALLOWED`       | 403  | 被拉黑 / 隐私 none / 隐私 friends | 无法给该用户发送私信     |
+| `PM_RECEIVER_NOT_FOUND`     | 404  | 收件人不存在                      | 收件人不存在             |
+| `PM_SEND_SELF`              | 400  | 发给自己                          | 不能给自己发私信         |
+| `PM_TOO_MANY_RECEIVERS`     | 400  | 收件人超 10 个                    | 收件人最多 10 个         |
+| `PM_CONTENT_INVALID`        | 400  | 标题/正文含非法字符               | 内容包含非法字符         |
+| `PM_CONVERSATION_NOT_FOUND` | 404  | 会话/消息不存在或无权访问         | 私信不存在               |
+| `RATE_LIMIT_EXCEEDED`       | 429  | 发送限流（复用现有，不改）        | 操作过于频繁，请稍后再试 |
+
+**隐私约定（需注意，勿破坏现状）**：
+
+- `被拉黑 / 隐私 none / 隐私 friends` 合并为同一个 `PM_SEND_NOT_ALLOWED`，
+  不向发件人泄露对方具体隐私配置。
+- 「消息不存在」与「你不是参与者」合并为同一个 `PM_CONVERSATION_NOT_FOUND`（404），
+  避免探测他人会话是否存在。因此 `assertCanReply` 中的「非参与者」分支建议也统一返回
+  该 404，而不是 `403`。
+
+字段长度校验（title ≤ 75、content ≤ 1000、receivers 1–10）继续由 TypeBox 校验产生
+`FST_ERR_VALIDATION`（400），前端会先本地校验拦截，此项无需改后端。
+
+---
+
+## 2. 移除 `GET /pm/conversations/:msgID` 的自动已读副作用（高优先级）
+
+### 现状
+
+`lib/pm/utils.ts` 的 `getConversation` 开头：
+
+```ts
+const rootID = msg.msgRelated;
+await markConversationRead(uid, rootID); // ← 副作用
+```
+
+路由 schema 的 `description` 也写着「会将会话内发给当前用户的消息标记为已读」。
+
+### 问题
+
+- GET 应幂等、无副作用。新前端用 SWR，默认在窗口重新聚焦、断线重连、重新挂载时自动
+  revalidate，会导致用户只是切标签页回来就可能把未读会话「误标已读」。
+- 后端已有独立的 `PUT /pm/conversations/:msgID/read`，语义重复。
+
+### 建议
+
+1. 删除 `getConversation` 内的 `markConversationRead` 调用。
+   （`markConversationRead` 函数本身保留，供 `markConversationReadByMessageID` 与
+   `PUT /read` 路由使用。）
+2. 更新路由 schema：`summary` 保持「获取私信会话详情」，删除 `description` 中自动已读说明。
+3. 前端契约改为：进入会话后显式调用 `PUT /pm/conversations/:msgID/read`。
+
+（若担心老调用方依赖，可退化为 opt-in `?markRead=true`，默认不标。推荐直接移除。）
+
+---
+
+## 3. 收件人支持 user ID（高优先级）
+
+### 现状
+
+`CreatePrivateMessage.receivers` 只接受 `string[]`（username），`resolveReceivers` 走
+`fetchSlimUserByUsername`。后端**没有用户搜索接口**（只有 subjects/characters/persons）。
+
+### 问题
+
+- 写信页只能「最近联系人（15 个）快捷选择」或「手动输入完整 username」，没有搜索/自动补全。
+- 输错一个字符即 404；用户改名后 username 失效。
+
+### 建议
+
+`lib/types/req.ts` 的 `CreatePrivateMessage` 增加 ID 传参，与 username 二选一：
+
+```ts
+receiverIDs: t.Optional(
+  t.Array(t.Integer(), { minItems: 1, maxItems: 10, description: '收件人 user id 列表，与 receivers 二选一' }),
+),
+```
+
+- `receivers` 与 `receiverIDs` 必须且只能提供一个。
+- 数量上限均为 10（去重后）。
+- ID 分支复用已有的 `fetchSlimUsersByIDs`（带缓存）；其余校验（不能发自己、拉黑/隐私、
+  上限）与 username 分支一致。
+
+备选（若允许 breaking change，PM 尚未对老前端开放）：直接把 `receivers` 改成
+`t.Array(t.Integer())`。推荐前者以保持兼容。
+
+### 可选：用户搜索接口（独立后续项，不阻塞）
+
+写信页收件人自动补全需要用户搜索，但现无用户搜索接口，且 Meilisearch 无 `users` 索引：
+
+- 轻量方案：MySQL `username/nickname LIKE` 查询（需评估性能与隐藏/封禁用户过滤）。
+- 标准方案：新增 Meilisearch `users` 索引 + 索引管线（较重，涉及用户隐私数据进搜索）。
+
+---
+
+## 4. 其他可选优化（不阻塞）
+
+### 4.1 socket `pm` 事件载荷太薄
+
+**现状**：事件载荷为 `{ msgID, related }`，前端更新未读数还需再请求 `/p1/pm`。
+
+**建议**：事件里带上未读计数（复用 `notify` 事件的 `{ count }` 模式）或发件人预览，
+减少一次往返。
+
+### 4.2 `getMailboxStatus` 计数语义不一致
+
+**现状**：`inbox`/`outbox` 返回**消息条数**（`count(*)`），而列表接口的 `total` 是
+**会话数**（`countDistinct(msgRelated)`）。
+
+**建议**：在 schema description 写清口径，或统一。前端 V1 主要用 `unread`，影响小。

--- a/drizzle/orm.ts
+++ b/drizzle/orm.ts
@@ -46,3 +46,5 @@ export type IGroupPost = typeof schema.chiiGroupPosts.$inferSelect;
 
 export type INotify = typeof schema.chiiNotify.$inferSelect;
 export type INotifyField = typeof schema.chiiNotifyField.$inferSelect;
+
+export type IPrivateMessage = typeof schema.chiiPms.$inferSelect;

--- a/lib/openapi/index.ts
+++ b/lib/openapi/index.ts
@@ -11,6 +11,7 @@ export const Tag = {
   Home: 'home',
   Index: 'index',
   Person: 'person',
+  Pm: 'pm',
   Relationship: 'relationship',
   Search: 'search',
   Subject: 'subject',

--- a/lib/pm/errors.ts
+++ b/lib/pm/errors.ts
@@ -1,0 +1,47 @@
+import { createError } from '@fastify/error';
+import { StatusCodes } from 'http-status-codes';
+
+/** 发件人自身被 ban_post 禁止（账户级，与收件人无关） */
+export const PmSendBannedError = createError<[]>(
+  'PM_SEND_BANNED',
+  'you are not allowed to send private message',
+  StatusCodes.FORBIDDEN,
+);
+
+/** 收件人侧拒绝：被拉黑 / 隐私 none / 隐私 friends（故意合并，保护隐私） */
+export const PmSendNotAllowedError = createError<[]>(
+  'PM_SEND_NOT_ALLOWED',
+  'cannot send private message to this user',
+  StatusCodes.FORBIDDEN,
+);
+
+export const PmReceiverNotFoundError = createError<[string]>(
+  'PM_RECEIVER_NOT_FOUND',
+  'user %s not found',
+  StatusCodes.NOT_FOUND,
+);
+
+export const PmSendSelfError = createError<[]>(
+  'PM_SEND_SELF',
+  'cannot send private message to yourself',
+  StatusCodes.BAD_REQUEST,
+);
+
+export const PmTooManyReceiversError = createError<[]>(
+  'PM_TOO_MANY_RECEIVERS',
+  'at most 10 receivers',
+  StatusCodes.BAD_REQUEST,
+);
+
+export const PmContentInvalidError = createError<[string]>(
+  'PM_CONTENT_INVALID',
+  '%s contains invalid invisible character',
+  StatusCodes.BAD_REQUEST,
+);
+
+/** 会话/消息不存在，或当前用户无权访问（故意合并为 404，避免探测） */
+export const PmConversationNotFoundError = createError<[string]>(
+  'PM_CONVERSATION_NOT_FOUND',
+  'private message %s not found',
+  StatusCodes.NOT_FOUND,
+);

--- a/lib/pm/type.ts
+++ b/lib/pm/type.ts
@@ -1,0 +1,25 @@
+/** 私信相关常量与类型 */
+
+export const PMFolder = Object.freeze({
+  Inbox: 'inbox',
+  Outbox: 'outbox',
+} as const);
+
+export type PMFolder = (typeof PMFolder)[keyof typeof PMFolder];
+
+/** Redis pub/sub channel 前缀，完整 channel 为 `${PREFIX}${uid}` */
+export const PM_EVENT_CHANNEL_PREFIX = 'event-user-pm-';
+
+export function getPmEventChannel(uid: number): string {
+  return `${PM_EVENT_CHANNEL_PREFIX}${uid}`;
+}
+
+/** Socket.io 推送的新私信事件载荷 */
+export interface PmEvent {
+  /** 新消息 id */
+  msgID: number;
+  /** 会话根消息 id */
+  related: number;
+  /** 接收者未读私信总数 */
+  count: number;
+}

--- a/lib/pm/utils.test.ts
+++ b/lib/pm/utils.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { db, op, type orm, schema } from '@app/drizzle';
+import redis from '@app/lib/redis.ts';
+import type * as res from '@app/lib/types/res.ts';
+
+import { canSendPM, toPrivateMessage } from './utils.ts';
+
+const senderID = 1;
+const receiverID = 287622;
+
+const sender: res.ISlimUser = {
+  id: senderID,
+  username: '1',
+  nickname: 'test',
+  avatar: { small: '', medium: '', large: '' },
+  group: 0,
+  sign: '',
+  joinedAt: 0,
+  isFriend: false,
+};
+
+describe('toPrivateMessage', () => {
+  test('should convert an unread message', () => {
+    const msg: orm.IPrivateMessage = {
+      msgId: 100,
+      msgSid: senderID,
+      msgRid: receiverID,
+      msgFolder: 'inbox',
+      msgNew: 1,
+      msgTitle: 'hello',
+      msgDateline: 123,
+      msgMessage: 'world',
+      msgRelatedMain: 100,
+      msgRelated: 100,
+      msgSdeleted: 0,
+      msgRdeleted: 0,
+    };
+
+    expect(toPrivateMessage(msg, sender)).toMatchObject({
+      id: 100,
+      sender: { id: senderID },
+      receiverID,
+      title: 'hello',
+      content: 'world',
+      createdAt: 123,
+      read: false,
+      related: 100,
+    });
+  });
+});
+
+describe('canSendPM', () => {
+  beforeEach(async () => {
+    await redis.flushdb();
+    await db
+      .update(schema.chiiUserFields)
+      .set({ privacy: '', blocklist: '' })
+      .where(op.eq(schema.chiiUserFields.uid, receiverID));
+  });
+
+  test('should allow by default', async () => {
+    await expect(canSendPM(senderID, receiverID)).resolves.toBe(true);
+  });
+
+  test('should disallow when privacy is none', async () => {
+    await db
+      .update(schema.chiiUserFields)
+      .set({ privacy: '{"1":2}' })
+      .where(op.eq(schema.chiiUserFields.uid, receiverID));
+
+    await expect(canSendPM(senderID, receiverID)).resolves.toBe(false);
+  });
+
+  test('should disallow when sender is blocked', async () => {
+    await db
+      .update(schema.chiiUserFields)
+      .set({ blocklist: String(senderID) })
+      .where(op.eq(schema.chiiUserFields.uid, receiverID));
+
+    await expect(canSendPM(senderID, receiverID)).resolves.toBe(false);
+  });
+});

--- a/lib/pm/utils.ts
+++ b/lib/pm/utils.ts
@@ -1,0 +1,555 @@
+import { DateTime } from 'luxon';
+
+import { db, op, type orm, schema, type Txn } from '@app/drizzle';
+import { BadRequestError, UnexpectedNotFoundError } from '@app/lib/error.ts';
+import redis from '@app/lib/redis.ts';
+import * as fetcher from '@app/lib/types/fetcher.ts';
+import type * as res from '@app/lib/types/res.ts';
+import { PrivacySettingKey, PrivacyValue, readPrivacySetting } from '@app/lib/user/privacy.ts';
+import { ghostUser, isFriends, parseBlocklist } from '@app/lib/user/utils.ts';
+
+import {
+  PmConversationNotFoundError,
+  PmReceiverNotFoundError,
+  PmSendNotAllowedError,
+  PmSendSelfError,
+  PmTooManyReceiversError,
+} from './errors.ts';
+import { getPmEventChannel, type PmEvent, type PMFolder } from './type.ts';
+
+export const MAX_RECEIVERS = 10;
+
+export function toPrivateMessage(
+  msg: orm.IPrivateMessage,
+  sender: res.ISlimUser,
+): res.IPrivateMessage {
+  return {
+    id: msg.msgId,
+    sender,
+    receiverID: msg.msgRid,
+    title: msg.msgTitle,
+    content: msg.msgMessage,
+    createdAt: msg.msgDateline,
+    read: msg.msgNew === 0,
+    related: msg.msgRelated,
+  };
+}
+
+function isVisibleTo(msg: orm.IPrivateMessage, uid: number): boolean {
+  if (msg.msgRid === uid) {
+    return msg.msgRdeleted === 0;
+  }
+  if (msg.msgSid === uid) {
+    return msg.msgSdeleted === 0;
+  }
+  return false;
+}
+
+async function recalcNewpm(t: Txn, uid: number): Promise<void> {
+  const [{ count = 0 } = {}] = await t
+    .select({ count: op.count() })
+    .from(schema.chiiPms)
+    .where(
+      op.and(
+        op.eq(schema.chiiPms.msgRid, uid),
+        op.eq(schema.chiiPms.msgRdeleted, 0),
+        op.eq(schema.chiiPms.msgNew, 1),
+      ),
+    );
+  await t
+    .update(schema.chiiUsers)
+    .set({ newpm: count > 0 ? 1 : 0 })
+    .where(op.eq(schema.chiiUsers.id, uid));
+}
+
+/** Sender 是否可以向 receiver 发送私信（拉黑 + 隐私设置，静默返回 false，不抛错） */
+export async function canSendPM(senderID: number, receiverID: number): Promise<boolean> {
+  const [uf] = await db
+    .select()
+    .from(schema.chiiUserFields)
+    .where(op.eq(schema.chiiUserFields.uid, receiverID))
+    .limit(1);
+  if (!uf) {
+    throw new UnexpectedNotFoundError(`user field ${receiverID}`);
+  }
+
+  if (parseBlocklist(uf.blocklist).includes(senderID)) {
+    return false;
+  }
+
+  const privacy = readPrivacySetting(uf.privacy, PrivacySettingKey.PrivateMessage);
+  if (privacy === PrivacyValue.None) {
+    return false;
+  }
+  if (privacy === PrivacyValue.Friends && !(await isFriends(receiverID, senderID))) {
+    return false;
+  }
+  return true;
+}
+
+function assertReceiver(senderID: number, user: res.ISlimUser): void {
+  if (user.id === senderID) {
+    throw new PmSendSelfError();
+  }
+}
+
+/** 解析并校验收件人（usernames 与 receiverIDs 必须且只能提供一个） */
+export async function resolveReceivers(
+  senderID: number,
+  options: { usernames?: readonly string[]; receiverIDs?: readonly number[] },
+): Promise<res.ISlimUser[]> {
+  const usernames = options.usernames ?? [];
+  const ids = options.receiverIDs ?? [];
+  const hasUsernames = usernames.length > 0;
+  const hasIDs = ids.length > 0;
+
+  if (hasUsernames === hasIDs) {
+    throw new BadRequestError('provide exactly one of receivers or receiverIDs');
+  }
+
+  const receivers: res.ISlimUser[] = [];
+  if (hasUsernames) {
+    const unique = [...new Set(usernames)];
+    if (unique.length > MAX_RECEIVERS) {
+      throw new PmTooManyReceiversError();
+    }
+    for (const username of unique) {
+      const user = await fetcher.fetchSlimUserByUsername(username);
+      if (!user) {
+        throw new PmReceiverNotFoundError(username);
+      }
+      assertReceiver(senderID, user);
+      receivers.push(user);
+    }
+  } else {
+    const unique = [...new Set(ids)];
+    if (unique.length > MAX_RECEIVERS) {
+      throw new PmTooManyReceiversError();
+    }
+    const users = await fetcher.fetchSlimUsersByIDs(unique);
+    for (const id of unique) {
+      const user = users[id];
+      if (!user) {
+        throw new PmReceiverNotFoundError(id.toString());
+      }
+      assertReceiver(senderID, user);
+      receivers.push(user);
+    }
+  }
+
+  return receivers;
+}
+
+async function assertCanReply(
+  senderID: number,
+  receiverID: number,
+  related: number,
+): Promise<void> {
+  const [root] = await db
+    .select()
+    .from(schema.chiiPms)
+    .where(op.eq(schema.chiiPms.msgId, related))
+    .limit(1);
+  if (!root) {
+    throw new PmConversationNotFoundError(related.toString());
+  }
+
+  const isSenderSide = root.msgSid === senderID && root.msgRid === receiverID;
+  const isReceiverSide = root.msgSid === receiverID && root.msgRid === senderID;
+  if (!isSenderSide && !isReceiverSide) {
+    throw new PmConversationNotFoundError(related.toString());
+  }
+}
+
+export interface SendPrivateMessageResult {
+  messages: { receiverID: number; msgID: number }[];
+}
+
+export async function sendPrivateMessage(
+  senderID: number,
+  receivers: readonly res.ISlimUser[],
+  title: string,
+  content: string,
+  related = 0,
+): Promise<SendPrivateMessageResult> {
+  const now = DateTime.now().toUnixInteger();
+  const result: SendPrivateMessageResult = { messages: [] };
+
+  // 原子校验：任一收件人被拒（拉黑 / 隐私 none / 隐私 friends），整体失败，不发送任何消息
+  for (const receiver of receivers) {
+    if (!(await canSendPM(senderID, receiver.id))) {
+      throw new PmSendNotAllowedError();
+    }
+  }
+
+  const receiverIDs = receivers.map((r) => r.id);
+
+  await db.transaction(async (t) => {
+    for (const receiverID of receiverIDs) {
+      const isNew = related === 0;
+      if (!isNew) {
+        await assertCanReply(senderID, receiverID, related);
+      }
+
+      const [{ insertId }] = await t.insert(schema.chiiPms).values({
+        msgSid: senderID,
+        msgRid: receiverID,
+        msgFolder: 'inbox',
+        msgNew: 1,
+        msgTitle: title,
+        msgDateline: now,
+        msgMessage: content,
+        msgRelated: isNew ? 0 : related,
+        msgRelatedMain: 0,
+        msgSdeleted: 0,
+        msgRdeleted: 0,
+      });
+
+      if (isNew) {
+        await t
+          .update(schema.chiiPms)
+          .set({ msgRelated: insertId, msgRelatedMain: insertId })
+          .where(op.eq(schema.chiiPms.msgId, insertId));
+      }
+
+      result.messages.push({ receiverID, msgID: insertId });
+    }
+
+    await t
+      .update(schema.chiiUsers)
+      .set({ newpm: 1 })
+      .where(op.inArray(schema.chiiUsers.id, receiverIDs));
+  });
+
+  // 事务提交后再推送事件，保证消费者能读到已提交的数据
+  const unreadCounts = await getUnreadCounts(receiverIDs);
+  for (const { receiverID, msgID } of result.messages) {
+    const event: PmEvent = {
+      msgID,
+      related: related === 0 ? msgID : related,
+      count: unreadCounts.get(receiverID) ?? 0,
+    };
+    await redis.publish(getPmEventChannel(receiverID), JSON.stringify(event));
+  }
+
+  return result;
+}
+
+async function getUnreadCounts(receiverIDs: readonly number[]): Promise<Map<number, number>> {
+  const rows = await db
+    .select({ uid: schema.chiiPms.msgRid, count: op.count() })
+    .from(schema.chiiPms)
+    .where(
+      op.and(
+        op.inArray(schema.chiiPms.msgRid, receiverIDs),
+        op.eq(schema.chiiPms.msgRdeleted, 0),
+        op.eq(schema.chiiPms.msgNew, 1),
+      ),
+    )
+    .groupBy(schema.chiiPms.msgRid);
+  return new Map(rows.map((r) => [r.uid, r.count]));
+}
+
+export async function getMailboxStatus(uid: number): Promise<res.IPrivateMessageStatus> {
+  const [[inbox], [outbox], [unread]] = await Promise.all([
+    db
+      .select({ count: op.count() })
+      .from(schema.chiiPms)
+      .where(op.and(op.eq(schema.chiiPms.msgRid, uid), op.eq(schema.chiiPms.msgRdeleted, 0))),
+    db
+      .select({ count: op.count() })
+      .from(schema.chiiPms)
+      .where(op.and(op.eq(schema.chiiPms.msgSid, uid), op.eq(schema.chiiPms.msgSdeleted, 0))),
+    db
+      .select({ count: op.count() })
+      .from(schema.chiiPms)
+      .where(
+        op.and(
+          op.eq(schema.chiiPms.msgRid, uid),
+          op.eq(schema.chiiPms.msgRdeleted, 0),
+          op.eq(schema.chiiPms.msgNew, 1),
+        ),
+      ),
+  ]);
+
+  return { inbox: inbox?.count ?? 0, outbox: outbox?.count ?? 0, unread: unread?.count ?? 0 };
+}
+
+export async function listConversations(
+  uid: number,
+  folder: PMFolder,
+  limit: number,
+  offset: number,
+): Promise<res.IPaged<res.IPrivateMessageConversation>> {
+  const isInbox = folder === 'inbox';
+  const visibleConditions = isInbox
+    ? [op.eq(schema.chiiPms.msgRid, uid), op.eq(schema.chiiPms.msgRdeleted, 0)]
+    : [op.eq(schema.chiiPms.msgSid, uid), op.eq(schema.chiiPms.msgSdeleted, 0)];
+
+  const [{ count = 0 } = {}] = await db
+    .select({ count: op.countDistinct(schema.chiiPms.msgRelated) })
+    .from(schema.chiiPms)
+    .where(op.and(...visibleConditions));
+
+  const groups = await db
+    .select({
+      rootID: schema.chiiPms.msgRelated,
+      lastDateline: op.max(schema.chiiPms.msgDateline),
+    })
+    .from(schema.chiiPms)
+    .where(op.and(...visibleConditions))
+    .groupBy(schema.chiiPms.msgRelated)
+    .orderBy(op.desc(op.max(schema.chiiPms.msgDateline)))
+    .limit(limit)
+    .offset(offset);
+
+  if (groups.length === 0) {
+    return { total: count, data: [] };
+  }
+
+  const rootIDs = groups.map((g) => g.rootID);
+
+  const allMessages = await db
+    .select()
+    .from(schema.chiiPms)
+    .where(op.and(op.inArray(schema.chiiPms.msgRelated, rootIDs), ...visibleConditions))
+    .orderBy(op.asc(schema.chiiPms.msgDateline), op.asc(schema.chiiPms.msgId));
+
+  const rootMessages = await db
+    .select()
+    .from(schema.chiiPms)
+    .where(op.inArray(schema.chiiPms.msgId, rootIDs));
+  const rootByID = new Map(rootMessages.map((m) => [m.msgId, m]));
+
+  const byRoot = new Map<number, orm.IPrivateMessage[]>();
+  for (const m of allMessages) {
+    const arr = byRoot.get(m.msgRelated) ?? [];
+    arr.push(m);
+    byRoot.set(m.msgRelated, arr);
+  }
+
+  const otherUIDs = new Set<number>();
+  const senderUIDs = new Set<number>();
+  for (const rootID of rootIDs) {
+    const root = rootByID.get(rootID);
+    if (root) {
+      const other = root.msgSid === uid ? root.msgRid : root.msgSid;
+      if (other !== 0) {
+        otherUIDs.add(other);
+      }
+    }
+    for (const m of byRoot.get(rootID) ?? []) {
+      if (m.msgSid !== 0) {
+        senderUIDs.add(m.msgSid);
+      }
+    }
+  }
+
+  const users = await fetcher.fetchSlimUsersByIDs([...otherUIDs, ...senderUIDs], uid);
+
+  const data: res.IPrivateMessageConversation[] = [];
+  for (const rootID of rootIDs) {
+    const root = rootByID.get(rootID);
+    const msgs = byRoot.get(rootID) ?? [];
+    if (msgs.length === 0) {
+      continue;
+    }
+    const lastMsg = msgs.at(-1);
+    if (!lastMsg) {
+      continue;
+    }
+    const otherUID = root
+      ? root.msgSid === uid
+        ? root.msgRid
+        : root.msgSid
+      : lastMsg.msgSid === uid
+        ? lastMsg.msgRid
+        : lastMsg.msgSid;
+    const lastSender =
+      lastMsg.msgSid === 0 ? ghostUser(0) : (users[lastMsg.msgSid] ?? ghostUser(lastMsg.msgSid));
+    const other = otherUID === 0 ? ghostUser(0) : (users[otherUID] ?? ghostUser(otherUID));
+
+    data.push({
+      id: rootID,
+      title: root?.msgTitle ?? lastMsg.msgTitle,
+      other,
+      lastMessage: toPrivateMessage(lastMsg, lastSender),
+      unreadCount: isInbox ? msgs.filter((m) => m.msgNew === 1).length : 0,
+      totalCount: msgs.length,
+    });
+  }
+
+  return { total: count, data };
+}
+
+export async function getConversation(
+  uid: number,
+  msgID: number,
+): Promise<res.IPrivateMessageConversationDetail> {
+  const [msg] = await db
+    .select()
+    .from(schema.chiiPms)
+    .where(op.eq(schema.chiiPms.msgId, msgID))
+    .limit(1);
+  if (!msg) {
+    throw new PmConversationNotFoundError(msgID.toString());
+  }
+  if (msg.msgSid !== uid && msg.msgRid !== uid) {
+    throw new PmConversationNotFoundError(msgID.toString());
+  }
+
+  const rootID = msg.msgRelated;
+
+  const messages = await db
+    .select()
+    .from(schema.chiiPms)
+    .where(op.eq(schema.chiiPms.msgRelated, rootID))
+    .orderBy(op.asc(schema.chiiPms.msgDateline), op.asc(schema.chiiPms.msgId));
+
+  const visible = messages.filter((m) => isVisibleTo(m, uid));
+
+  const [rootMsg] = await db
+    .select()
+    .from(schema.chiiPms)
+    .where(op.eq(schema.chiiPms.msgId, rootID))
+    .limit(1);
+
+  const otherUID = rootMsg
+    ? rootMsg.msgSid === uid
+      ? rootMsg.msgRid
+      : rootMsg.msgSid
+    : msg.msgSid === uid
+      ? msg.msgRid
+      : msg.msgSid;
+
+  const senderUIDs = [...new Set(visible.map((m) => m.msgSid).filter((id) => id !== 0))];
+  const users = await fetcher.fetchSlimUsersByIDs(senderUIDs, uid);
+
+  const other = otherUID === 0 ? ghostUser(0) : (users[otherUID] ?? ghostUser(otherUID));
+  const data = visible.map((m) =>
+    toPrivateMessage(m, m.msgSid === 0 ? ghostUser(0) : (users[m.msgSid] ?? ghostUser(m.msgSid))),
+  );
+
+  const conversation: res.IPrivateMessageConversation = {
+    id: rootID,
+    title: rootMsg?.msgTitle ?? msg.msgTitle,
+    other,
+    lastMessage: data.at(-1) ?? toPrivateMessage(msg, other),
+    unreadCount: visible.filter((m) => m.msgRid === uid && m.msgNew === 1).length,
+    totalCount: data.length,
+  };
+
+  return { conversation, messages: data };
+}
+
+export async function markConversationRead(uid: number, rootID: number): Promise<void> {
+  await db.transaction(async (t) => {
+    await t
+      .update(schema.chiiPms)
+      .set({ msgNew: 0 })
+      .where(
+        op.and(
+          op.eq(schema.chiiPms.msgRelated, rootID),
+          op.eq(schema.chiiPms.msgRid, uid),
+          op.eq(schema.chiiPms.msgNew, 1),
+        ),
+      );
+    await recalcNewpm(t, uid);
+  });
+}
+
+/** 通过会话内任意一条消息 id 标记整个会话已读 */
+export async function markConversationReadByMessageID(uid: number, msgID: number): Promise<void> {
+  const [msg] = await db
+    .select()
+    .from(schema.chiiPms)
+    .where(op.eq(schema.chiiPms.msgId, msgID))
+    .limit(1);
+  if (!msg) {
+    throw new PmConversationNotFoundError(msgID.toString());
+  }
+  if (msg.msgSid !== uid && msg.msgRid !== uid) {
+    throw new PmConversationNotFoundError(msgID.toString());
+  }
+  await markConversationRead(uid, msg.msgRelated);
+}
+
+export async function deleteMessage(uid: number, msgID: number): Promise<void> {
+  const [msg] = await db
+    .select()
+    .from(schema.chiiPms)
+    .where(op.eq(schema.chiiPms.msgId, msgID))
+    .limit(1);
+  if (!msg) {
+    throw new PmConversationNotFoundError(msgID.toString());
+  }
+  if (msg.msgSid !== uid && msg.msgRid !== uid) {
+    throw new PmConversationNotFoundError(msgID.toString());
+  }
+
+  await db.transaction(async (t) => {
+    if (msg.msgSid === uid) {
+      await t
+        .update(schema.chiiPms)
+        .set({ msgSdeleted: 1 })
+        .where(op.eq(schema.chiiPms.msgId, msgID));
+    } else {
+      await t
+        .update(schema.chiiPms)
+        .set({ msgRdeleted: 1, msgNew: 0 })
+        .where(op.eq(schema.chiiPms.msgId, msgID));
+      await recalcNewpm(t, uid);
+    }
+  });
+}
+
+export async function deleteConversation(uid: number, msgID: number): Promise<void> {
+  const [msg] = await db
+    .select()
+    .from(schema.chiiPms)
+    .where(op.eq(schema.chiiPms.msgId, msgID))
+    .limit(1);
+  if (!msg) {
+    throw new PmConversationNotFoundError(msgID.toString());
+  }
+  if (msg.msgSid !== uid && msg.msgRid !== uid) {
+    throw new PmConversationNotFoundError(msgID.toString());
+  }
+
+  const rootID = msg.msgRelated;
+  await db.transaction(async (t) => {
+    await t
+      .update(schema.chiiPms)
+      .set({ msgRdeleted: 1, msgNew: 0 })
+      .where(op.and(op.eq(schema.chiiPms.msgRelated, rootID), op.eq(schema.chiiPms.msgRid, uid)));
+    await t
+      .update(schema.chiiPms)
+      .set({ msgSdeleted: 1 })
+      .where(op.and(op.eq(schema.chiiPms.msgRelated, rootID), op.eq(schema.chiiPms.msgSid, uid)));
+    await recalcNewpm(t, uid);
+  });
+}
+
+export async function listRecentContacts(uid: number): Promise<res.IPrivateMessageContact[]> {
+  const rows = await db
+    .select({
+      receiverID: schema.chiiPms.msgRid,
+      lastDateline: op.max(schema.chiiPms.msgDateline),
+    })
+    .from(schema.chiiPms)
+    .where(op.eq(schema.chiiPms.msgSid, uid))
+    .groupBy(schema.chiiPms.msgRid)
+    .orderBy(op.desc(op.max(schema.chiiPms.msgDateline)))
+    .limit(15);
+
+  const contacts = rows.filter((r) => r.receiverID !== uid && r.receiverID !== 0);
+  const users = await fetcher.fetchSlimUsersByIDs(
+    contacts.map((c) => c.receiverID),
+    uid,
+  );
+
+  return contacts.map((c) => ({
+    user: users[c.receiverID] ?? ghostUser(c.receiverID),
+    lastMessageAt: c.lastDateline ?? 0,
+  }));
+}

--- a/lib/types/req.ts
+++ b/lib/types/req.ts
@@ -470,3 +470,27 @@ export const CharacterEdit = t.Object(
     additionalProperties: false,
   },
 );
+
+export type ICreatePrivateMessage = Static<typeof CreatePrivateMessage>;
+export const CreatePrivateMessage = t.Object(
+  {
+    receivers: t.Optional(
+      t.Array(t.String({ minLength: 1 }), {
+        minItems: 1,
+        maxItems: 10,
+        description: '收件人 username 列表，与 receiverIDs 二选一',
+      }),
+    ),
+    receiverIDs: t.Optional(
+      t.Array(t.Integer(), {
+        minItems: 1,
+        maxItems: 10,
+        description: '收件人 user id 列表，与 receivers 二选一',
+      }),
+    ),
+    title: t.String({ minLength: 1, maxLength: 75 }),
+    content: t.String({ minLength: 1, maxLength: 1000 }),
+    related: t.Optional(t.Integer({ description: '回复时传入会话根消息 id，不传则创建新会话' })),
+  },
+  { $id: 'CreatePrivateMessage', title: 'CreatePrivateMessage' },
+);

--- a/lib/types/res.ts
+++ b/lib/types/res.ts
@@ -1293,3 +1293,59 @@ export const CharacterRevisionWikiInfo = t.Object(
     $id: 'CharacterRevisionWikiInfo',
   },
 );
+
+export type IPrivateMessage = Static<typeof PrivateMessage>;
+export const PrivateMessage = t.Object(
+  {
+    id: t.Integer(),
+    sender: Ref(SlimUser),
+    receiverID: t.Integer(),
+    title: t.String(),
+    content: t.String(),
+    createdAt: t.Integer({ description: 'unix timestamp seconds' }),
+    read: t.Boolean({ description: '接收者是否已读' }),
+    related: t.Integer({ description: '会话根消息 id (msg_related)' }),
+  },
+  { $id: 'PrivateMessage', title: 'PrivateMessage' },
+);
+
+export type IPrivateMessageConversation = Static<typeof PrivateMessageConversation>;
+export const PrivateMessageConversation = t.Object(
+  {
+    id: t.Integer({ description: '会话根消息 id (msg_related)' }),
+    title: t.String(),
+    other: Ref(SlimUser),
+    lastMessage: Ref(PrivateMessage),
+    unreadCount: t.Integer(),
+    totalCount: t.Integer(),
+  },
+  { $id: 'PrivateMessageConversation', title: 'PrivateMessageConversation' },
+);
+
+export type IPrivateMessageStatus = Static<typeof PrivateMessageStatus>;
+export const PrivateMessageStatus = t.Object(
+  {
+    inbox: t.Integer({ description: '收件箱消息条数（注意：会话列表接口的 total 为会话数）' }),
+    outbox: t.Integer({ description: '发件箱消息条数（注意：会话列表接口的 total 为会话数）' }),
+    unread: t.Integer({ description: '未读私信消息条数' }),
+  },
+  { $id: 'PrivateMessageStatus', title: 'PrivateMessageStatus' },
+);
+
+export type IPrivateMessageContact = Static<typeof PrivateMessageContact>;
+export const PrivateMessageContact = t.Object(
+  {
+    user: Ref(SlimUser),
+    lastMessageAt: t.Integer(),
+  },
+  { $id: 'PrivateMessageContact', title: 'PrivateMessageContact' },
+);
+
+export type IPrivateMessageConversationDetail = Static<typeof PrivateMessageConversationDetail>;
+export const PrivateMessageConversationDetail = t.Object(
+  {
+    conversation: Ref(PrivateMessageConversation),
+    messages: t.Array(Ref(PrivateMessage)),
+  },
+  { $id: 'PrivateMessageConversationDetail', title: 'PrivateMessageConversationDetail' },
+);

--- a/lib/utils/rate-limit/index.ts
+++ b/lib/utils/rate-limit/index.ts
@@ -115,6 +115,13 @@ export const LimitAction = Object.freeze({
    * 5 分钟 30 次
    */
   Wiki: { action: 'wiki', limit: 30, durationMinutes: 5 },
+
+  /**
+   * 发送私信
+   *
+   * 1 分钟 60 次
+   */
+  Pm: { action: 'pm', limit: 60, durationMinutes: 1 },
 } as const satisfies Record<string, LimitRule>);
 
 export interface Result {

--- a/openapi.json
+++ b/openapi.json
@@ -419,6 +419,46 @@
         },
         "title": "CreateIndexRelated"
       },
+      "CreatePrivateMessage": {
+        "type": "object",
+        "required": ["title", "content"],
+        "properties": {
+          "receivers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "maxItems": 10,
+            "description": "收件人 username 列表，与 receiverIDs 二选一"
+          },
+          "receiverIDs": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "minItems": 1,
+            "maxItems": 10,
+            "description": "收件人 user id 列表，与 receivers 二选一"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 75
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000
+          },
+          "related": {
+            "type": "integer",
+            "description": "回复时传入会话根消息 id，不传则创建新会话"
+          }
+        },
+        "title": "CreatePrivateMessage"
+      },
       "CreateReply": {
         "type": "object",
         "required": ["content"],
@@ -2105,6 +2145,123 @@
           }
         },
         "title": "Post"
+      },
+      "PrivateMessage": {
+        "type": "object",
+        "required": [
+          "id",
+          "sender",
+          "receiverID",
+          "title",
+          "content",
+          "createdAt",
+          "read",
+          "related"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "sender": {
+            "$ref": "#/components/schemas/SlimUser"
+          },
+          "receiverID": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "integer",
+            "description": "unix timestamp seconds"
+          },
+          "read": {
+            "type": "boolean",
+            "description": "接收者是否已读"
+          },
+          "related": {
+            "type": "integer",
+            "description": "会话根消息 id (msg_related)"
+          }
+        },
+        "title": "PrivateMessage"
+      },
+      "PrivateMessageContact": {
+        "type": "object",
+        "required": ["user", "lastMessageAt"],
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/SlimUser"
+          },
+          "lastMessageAt": {
+            "type": "integer"
+          }
+        },
+        "title": "PrivateMessageContact"
+      },
+      "PrivateMessageConversation": {
+        "type": "object",
+        "required": ["id", "title", "other", "lastMessage", "unreadCount", "totalCount"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "会话根消息 id (msg_related)"
+          },
+          "title": {
+            "type": "string"
+          },
+          "other": {
+            "$ref": "#/components/schemas/SlimUser"
+          },
+          "lastMessage": {
+            "$ref": "#/components/schemas/PrivateMessage"
+          },
+          "unreadCount": {
+            "type": "integer"
+          },
+          "totalCount": {
+            "type": "integer"
+          }
+        },
+        "title": "PrivateMessageConversation"
+      },
+      "PrivateMessageConversationDetail": {
+        "type": "object",
+        "required": ["conversation", "messages"],
+        "properties": {
+          "conversation": {
+            "$ref": "#/components/schemas/PrivateMessageConversation"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateMessage"
+            }
+          }
+        },
+        "title": "PrivateMessageConversationDetail"
+      },
+      "PrivateMessageStatus": {
+        "type": "object",
+        "required": ["inbox", "outbox", "unread"],
+        "properties": {
+          "inbox": {
+            "type": "integer",
+            "description": "收件箱消息条数（注意：会话列表接口的 total 为会话数）"
+          },
+          "outbox": {
+            "type": "integer",
+            "description": "发件箱消息条数（注意：会话列表接口的 total 为会话数）"
+          },
+          "unread": {
+            "type": "integer",
+            "description": "未读私信消息条数"
+          }
+        },
+        "title": "PrivateMessageStatus"
       },
       "Profile": {
         "type": "object",
@@ -11932,6 +12089,549 @@
                 "schema": {
                   "type": "object",
                   "properties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/pm": {
+      "get": {
+        "operationId": "getPrivateMessageStatus",
+        "summary": "获取私信邮箱状态",
+        "tags": ["pm"],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateMessageStatus"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createPrivateMessage",
+        "summary": "发送私信",
+        "tags": ["pm"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePrivateMessage"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["messages"],
+                  "properties": {
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": ["receiverID", "msgID"],
+                        "properties": {
+                          "receiverID": {
+                            "type": "integer"
+                          },
+                          "msgID": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/pm/inbox": {
+      "get": {
+        "operationId": "listPrivateMessageInbox",
+        "summary": "获取收件箱会话列表",
+        "tags": ["pm"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "max 100"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "description": "min 0"
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data", "total"],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateMessageConversation"
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/pm/outbox": {
+      "get": {
+        "operationId": "listPrivateMessageOutbox",
+        "summary": "获取发件箱会话列表",
+        "tags": ["pm"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "max 100"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "description": "min 0"
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data", "total"],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateMessageConversation"
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/pm/contacts": {
+      "get": {
+        "operationId": "listPrivateMessageContacts",
+        "summary": "获取最近私信联系人",
+        "tags": ["pm"],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PrivateMessageContact"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/pm/conversations/{msgID}": {
+      "get": {
+        "operationId": "getPrivateMessageConversation",
+        "summary": "获取私信会话详情",
+        "tags": ["pm"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "msgID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateMessageConversationDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deletePrivateMessageConversation",
+        "summary": "删除私信会话",
+        "tags": ["pm"],
+        "description": "仅对当前用户软删除，不影响会话对方",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "msgID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/pm/conversations/{msgID}/read": {
+      "put": {
+        "operationId": "markPrivateMessageConversationRead",
+        "summary": "标记私信会话已读",
+        "tags": ["pm"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "msgID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/pm/{msgID}": {
+      "delete": {
+        "operationId": "deletePrivateMessage",
+        "summary": "删除单条私信",
+        "tags": ["pm"],
+        "description": "仅对当前用户软删除，不影响对方",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "msgID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/routes/private/index.ts
+++ b/routes/private/index.ts
@@ -22,6 +22,7 @@ import * as index from './routes/index.ts';
 import * as misc from './routes/misc.ts';
 import * as passkey from './routes/passkey.ts';
 import * as person from './routes/person.ts';
+import * as pm from './routes/pm.ts';
 import * as privacy from './routes/privacy.ts';
 import * as friend from './routes/relationship.ts';
 import * as report from './routes/report.ts';
@@ -94,6 +95,7 @@ async function API(app: App) {
   await app.register(misc.setup);
   await app.register(passkey.setup);
   await app.register(person.setup);
+  await app.register(pm.setup);
   await app.register(privacy.setup);
   await app.register(report.setup);
   await app.register(search.setup);

--- a/routes/private/routes/misc.ts
+++ b/routes/private/routes/misc.ts
@@ -10,6 +10,7 @@ import { UnexpectedNotFoundError } from '@app/lib/error.ts';
 import { avatar } from '@app/lib/images';
 import { Notify } from '@app/lib/notify.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
+import { getPmEventChannel, type PmEvent } from '@app/lib/pm/type.ts';
 import { Subscriber } from '@app/lib/redis.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
 import * as res from '@app/lib/types/res.ts';
@@ -175,19 +176,32 @@ export async function setup(app: App) {
     }
 
     const userID = a.userID;
-    const watch = `event-user-notify-${userID}`;
+    const notifyWatch = `event-user-notify-${userID}`;
+    const pmWatch = getPmEventChannel(userID);
 
     const send = (count: number) => {
       socket.emit('notify', JSON.stringify({ count }));
     };
 
+    const sendPm = (event: PmEvent) => {
+      socket.emit('pm', JSON.stringify(event));
+    };
+
     const callback = (pattern: string, ch: string, msg: string) => {
-      if (ch !== watch) {
+      if (ch === notifyWatch) {
+        const { new_notify } = JSON.parse(msg) as { new_notify: number };
+        send(new_notify);
         return;
       }
 
-      const { new_notify } = JSON.parse(msg) as { new_notify: number };
-      send(new_notify);
+      if (ch === pmWatch) {
+        try {
+          const event = JSON.parse(msg) as PmEvent;
+          sendPm(event);
+        } catch {
+          // 忽略无法解析的私信事件
+        }
+      }
     };
 
     Subscriber.addListener('pmessage', callback);

--- a/routes/private/routes/pm.test.ts
+++ b/routes/private/routes/pm.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { db, op, schema } from '@app/drizzle';
+import { emptyAuth } from '@app/lib/auth/index.ts';
+import redis from '@app/lib/redis.ts';
+import { createTestServer } from '@app/tests/utils.ts';
+
+import { setup } from './pm.ts';
+
+const senderID = 1;
+const receiverID = 287622;
+const otherReceiverID = 382951;
+
+function appWith(userID: number) {
+  return createTestServer({
+    auth: {
+      ...emptyAuth(),
+      login: true,
+      userID,
+    },
+  });
+}
+
+async function clearPmData() {
+  await db
+    .delete(schema.chiiPms)
+    .where(
+      op.or(
+        op.or(op.eq(schema.chiiPms.msgSid, senderID), op.eq(schema.chiiPms.msgRid, senderID)),
+        op.or(op.eq(schema.chiiPms.msgSid, receiverID), op.eq(schema.chiiPms.msgRid, receiverID)),
+      ),
+    );
+  await db
+    .update(schema.chiiUserFields)
+    .set({ privacy: '', blocklist: '' })
+    .where(op.inArray(schema.chiiUserFields.uid, [senderID, receiverID, otherReceiverID]));
+  await db
+    .update(schema.chiiUsers)
+    .set({ newpm: 0 })
+    .where(op.inArray(schema.chiiUsers.id, [senderID, receiverID]));
+}
+
+describe('private message', () => {
+  beforeEach(async () => {
+    await redis.flushdb();
+    await clearPmData();
+  });
+
+  afterEach(async () => {
+    await redis.flushdb();
+    await clearPmData();
+  });
+
+  test('should send a new private message', async () => {
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: {
+        receivers: ['287622'],
+        title: 'hello',
+        content: 'world',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      messages: [{ receiverID, msgID: expect.any(Number) }],
+    });
+
+    const msgID = res.json().messages[0].msgID;
+    const [msg] = await db.select().from(schema.chiiPms).where(op.eq(schema.chiiPms.msgId, msgID));
+    expect(msg).toBeDefined();
+    expect(msg?.msgSid).toBe(senderID);
+    expect(msg?.msgRid).toBe(receiverID);
+    expect(msg?.msgNew).toBe(1);
+    expect(msg?.msgRelated).toBe(msgID);
+    expect(msg?.msgRelatedMain).toBe(msgID);
+
+    const [receiver] = await db
+      .select()
+      .from(schema.chiiUsers)
+      .where(op.eq(schema.chiiUsers.id, receiverID));
+    expect(receiver?.newpm).toBe(1);
+  });
+
+  test('should reject sending to self', async () => {
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: {
+        receivers: ['1'],
+        title: 'hello',
+        content: 'world',
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should reject sending to nonexistent user', async () => {
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: {
+        receivers: ['no-such-user'],
+        title: 'hello',
+        content: 'world',
+      },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('should reject with 403 when receiver privacy is none', async () => {
+    await db
+      .update(schema.chiiUserFields)
+      .set({ privacy: '{"1":2}' })
+      .where(op.eq(schema.chiiUserFields.uid, receiverID));
+
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: {
+        receivers: ['287622'],
+        title: 'hello',
+        content: 'world',
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('PM_SEND_NOT_ALLOWED');
+
+    const [msg] = await db
+      .select()
+      .from(schema.chiiPms)
+      .where(op.eq(schema.chiiPms.msgSid, senderID));
+    expect(msg).toBeUndefined();
+  });
+
+  test('should reject with 403 when sender is in receiver blocklist', async () => {
+    await db
+      .update(schema.chiiUserFields)
+      .set({ blocklist: String(senderID) })
+      .where(op.eq(schema.chiiUserFields.uid, receiverID));
+
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: {
+        receivers: ['287622'],
+        title: 'hello',
+        content: 'world',
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('PM_SEND_NOT_ALLOWED');
+
+    const [msg] = await db
+      .select()
+      .from(schema.chiiPms)
+      .where(op.eq(schema.chiiPms.msgSid, senderID));
+    expect(msg).toBeUndefined();
+  });
+
+  test('should reject whole send when any receiver is not allowed', async () => {
+    await db
+      .update(schema.chiiUserFields)
+      .set({ blocklist: String(senderID) })
+      .where(op.eq(schema.chiiUserFields.uid, receiverID));
+
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: {
+        receiverIDs: [receiverID, otherReceiverID],
+        title: 'hello',
+        content: 'world',
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('PM_SEND_NOT_ALLOWED');
+
+    const [msg] = await db
+      .select()
+      .from(schema.chiiPms)
+      .where(op.eq(schema.chiiPms.msgSid, senderID));
+    expect(msg).toBeUndefined();
+  });
+
+  test('should reply to an existing conversation', async () => {
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: {
+        receivers: ['287622'],
+        title: 'hello',
+        content: 'first',
+      },
+    });
+    const rootID = res.json().messages[0].msgID;
+
+    const res2 = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: {
+        receivers: ['287622'],
+        title: 'Re: hello',
+        content: 'second',
+        related: rootID,
+      },
+    });
+    expect(res2.statusCode).toBe(200);
+
+    const replyID = res2.json().messages[0].msgID;
+    const [reply] = await db
+      .select()
+      .from(schema.chiiPms)
+      .where(op.eq(schema.chiiPms.msgId, replyID));
+    expect(reply?.msgRelated).toBe(rootID);
+    expect(reply?.msgRelatedMain).toBe(0);
+  });
+
+  test('should list inbox and outbox conversations', async () => {
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: { receivers: ['287622'], title: 'hello', content: 'world' },
+    });
+
+    const inbox = await app.inject('/pm/inbox');
+    expect(inbox.statusCode).toBe(200);
+    expect(inbox.json().total).toBe(0);
+
+    const outbox = await app.inject('/pm/outbox');
+    expect(outbox.statusCode).toBe(200);
+    expect(outbox.json().total).toBe(1);
+    expect(outbox.json().data).toHaveLength(1);
+    expect(outbox.json().data[0]).toMatchObject({
+      title: 'hello',
+      totalCount: 1,
+      unreadCount: 0,
+    });
+    expect(outbox.json().data[0].other).toMatchObject({ id: receiverID });
+    expect(outbox.json().data[0].lastMessage).toMatchObject({
+      title: 'hello',
+      content: 'world',
+      receiverID,
+    });
+  });
+
+  test('should get conversation without marking read, then mark read explicitly', async () => {
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: { receivers: ['287622'], title: 'hello', content: 'world' },
+    });
+    const msgID = res.json().messages[0].msgID;
+
+    const receiverApp = appWith(receiverID);
+    await receiverApp.register(setup);
+
+    const detail = await receiverApp.inject(`/pm/conversations/${msgID}`);
+    expect(detail.statusCode).toBe(200);
+    expect(detail.json().messages).toHaveLength(1);
+    expect(detail.json().messages[0]).toMatchObject({ read: false });
+    expect(detail.json().conversation).toMatchObject({
+      id: msgID,
+      title: 'hello',
+      unreadCount: 1,
+      totalCount: 1,
+    });
+    expect(detail.json().conversation.other).toMatchObject({ id: senderID });
+
+    let [msg] = await db.select().from(schema.chiiPms).where(op.eq(schema.chiiPms.msgId, msgID));
+    expect(msg?.msgNew).toBe(1);
+
+    const read = await receiverApp.inject({
+      method: 'put',
+      url: `/pm/conversations/${msgID}/read`,
+    });
+    expect(read.statusCode).toBe(200);
+
+    [msg] = await db.select().from(schema.chiiPms).where(op.eq(schema.chiiPms.msgId, msgID));
+    expect(msg?.msgNew).toBe(0);
+
+    const [receiver] = await db
+      .select()
+      .from(schema.chiiUsers)
+      .where(op.eq(schema.chiiUsers.id, receiverID));
+    expect(receiver?.newpm).toBe(0);
+  });
+
+  test('should delete a conversation', async () => {
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: { receivers: ['287622'], title: 'hello', content: 'world' },
+    });
+    const msgID = res.json().messages[0].msgID;
+
+    const receiverApp = appWith(receiverID);
+    await receiverApp.register(setup);
+    const del = await receiverApp.inject({
+      method: 'delete',
+      url: `/pm/conversations/${msgID}`,
+    });
+    expect(del.statusCode).toBe(200);
+
+    const [msg] = await db.select().from(schema.chiiPms).where(op.eq(schema.chiiPms.msgId, msgID));
+    expect(msg?.msgRdeleted).toBe(1);
+
+    const inbox = await receiverApp.inject('/pm/inbox');
+    expect(inbox.json().total).toBe(0);
+  });
+
+  test('should get mailbox status and contacts', async () => {
+    const app = appWith(senderID);
+    await app.register(setup);
+
+    const status = await app.inject('/pm');
+    expect(status.statusCode).toBe(200);
+    expect(status.json()).toMatchObject({ inbox: 0, outbox: 0, unread: 0 });
+
+    await app.inject({
+      method: 'post',
+      url: '/pm',
+      payload: { receivers: ['287622'], title: 'hello', content: 'world' },
+    });
+
+    const status2 = await app.inject('/pm');
+    expect(status2.json()).toMatchObject({ inbox: 0, outbox: 1, unread: 0 });
+
+    const contacts = await app.inject('/pm/contacts');
+    expect(contacts.statusCode).toBe(200);
+    expect(contacts.json()).toHaveLength(1);
+    expect(contacts.json()[0].user).toMatchObject({ id: receiverID });
+  });
+});

--- a/routes/private/routes/pm.ts
+++ b/routes/private/routes/pm.ts
@@ -1,0 +1,273 @@
+import t from 'typebox';
+
+import { Dam } from '@app/lib/dam.ts';
+import { Security, Tag } from '@app/lib/openapi/index.ts';
+import {
+  PmContentInvalidError,
+  PmConversationNotFoundError,
+  PmReceiverNotFoundError,
+  PmSendBannedError,
+  PmSendNotAllowedError,
+  PmSendSelfError,
+  PmTooManyReceiversError,
+} from '@app/lib/pm/errors.ts';
+import { PMFolder } from '@app/lib/pm/type.ts';
+import {
+  deleteConversation,
+  deleteMessage,
+  getConversation,
+  getMailboxStatus,
+  listConversations,
+  listRecentContacts,
+  markConversationReadByMessageID,
+  resolveReceivers,
+  sendPrivateMessage,
+} from '@app/lib/pm/utils.ts';
+import * as req from '@app/lib/types/req.ts';
+import * as res from '@app/lib/types/res.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
+import { requireLogin } from '@app/routes/hooks/pre-handler.ts';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
+import type { App } from '@app/routes/type.ts';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function setup(app: App) {
+  app.get(
+    '/pm',
+    {
+      schema: {
+        summary: '获取私信邮箱状态',
+        operationId: 'getPrivateMessageStatus',
+        tags: [Tag.Pm],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        response: {
+          200: res.Ref(res.PrivateMessageStatus),
+        },
+      },
+      preHandler: [requireLogin('get private message status')],
+    },
+    async ({ auth }) => {
+      return getMailboxStatus(auth.userID);
+    },
+  );
+
+  app.get(
+    '/pm/inbox',
+    {
+      schema: {
+        summary: '获取收件箱会话列表',
+        operationId: 'listPrivateMessageInbox',
+        tags: [Tag.Pm],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        querystring: t.Object({
+          limit: t.Optional(
+            t.Integer({ default: 20, minimum: 1, maximum: 100, description: 'max 100' }),
+          ),
+          offset: t.Optional(t.Integer({ default: 0, minimum: 0, description: 'min 0' })),
+        }),
+        response: {
+          200: res.Paged(res.Ref(res.PrivateMessageConversation)),
+        },
+      },
+      preHandler: [requireLogin('list private message inbox')],
+    },
+    async ({ auth, query: { limit = 20, offset = 0 } }) => {
+      return listConversations(auth.userID, PMFolder.Inbox, limit, offset);
+    },
+  );
+
+  app.get(
+    '/pm/outbox',
+    {
+      schema: {
+        summary: '获取发件箱会话列表',
+        operationId: 'listPrivateMessageOutbox',
+        tags: [Tag.Pm],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        querystring: t.Object({
+          limit: t.Optional(
+            t.Integer({ default: 20, minimum: 1, maximum: 100, description: 'max 100' }),
+          ),
+          offset: t.Optional(t.Integer({ default: 0, minimum: 0, description: 'min 0' })),
+        }),
+        response: {
+          200: res.Paged(res.Ref(res.PrivateMessageConversation)),
+        },
+      },
+      preHandler: [requireLogin('list private message outbox')],
+    },
+    async ({ auth, query: { limit = 20, offset = 0 } }) => {
+      return listConversations(auth.userID, PMFolder.Outbox, limit, offset);
+    },
+  );
+
+  app.get(
+    '/pm/contacts',
+    {
+      schema: {
+        summary: '获取最近私信联系人',
+        operationId: 'listPrivateMessageContacts',
+        tags: [Tag.Pm],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        response: {
+          200: t.Array(res.Ref(res.PrivateMessageContact)),
+        },
+      },
+      preHandler: [requireLogin('list private message contacts')],
+    },
+    async ({ auth }) => {
+      return listRecentContacts(auth.userID);
+    },
+  );
+
+  app.post(
+    '/pm',
+    {
+      schema: {
+        summary: '发送私信',
+        operationId: 'createPrivateMessage',
+        tags: [Tag.Pm],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        body: req.Ref(req.CreatePrivateMessage),
+        response: {
+          200: t.Object({
+            messages: t.Array(
+              t.Object({
+                receiverID: t.Integer(),
+                msgID: t.Integer(),
+              }),
+            ),
+          }),
+          ...res.errorResponses(
+            PmSendBannedError(),
+            PmSendNotAllowedError(),
+            PmReceiverNotFoundError('user'),
+            PmSendSelfError(),
+            PmTooManyReceiversError(),
+            PmContentInvalidError('title'),
+          ),
+          429: res.Ref(res.Error),
+        },
+      },
+      preHandler: [requireLogin('send private message')],
+    },
+    async ({ auth, body: { receivers, receiverIDs, title, content, related = 0 } }) => {
+      if (auth.permission.ban_post) {
+        throw new PmSendBannedError();
+      }
+      if (!Dam.allCharacterPrintable(title)) {
+        throw new PmContentInvalidError('title');
+      }
+      if (!Dam.allCharacterPrintable(content)) {
+        throw new PmContentInvalidError('content');
+      }
+
+      await rateLimit(LimitAction.Pm, auth.userID);
+
+      const receiverUsers = await resolveReceivers(auth.userID, {
+        usernames: receivers,
+        receiverIDs,
+      });
+      const result = await sendPrivateMessage(auth.userID, receiverUsers, title, content, related);
+
+      return { messages: result.messages };
+    },
+  );
+
+  app.get(
+    '/pm/conversations/:msgID',
+    {
+      schema: {
+        summary: '获取私信会话详情',
+        operationId: 'getPrivateMessageConversation',
+        tags: [Tag.Pm],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          msgID: t.Integer(),
+        }),
+        response: {
+          200: res.Ref(res.PrivateMessageConversationDetail),
+          ...res.errorResponses(PmConversationNotFoundError('message')),
+        },
+      },
+      preHandler: [requireLogin('get private message conversation')],
+    },
+    async ({ auth, params: { msgID } }) => {
+      return getConversation(auth.userID, msgID);
+    },
+  );
+
+  app.put(
+    '/pm/conversations/:msgID/read',
+    {
+      schema: {
+        summary: '标记私信会话已读',
+        operationId: 'markPrivateMessageConversationRead',
+        tags: [Tag.Pm],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          msgID: t.Integer(),
+        }),
+        response: {
+          200: t.Object({}),
+          ...res.errorResponses(PmConversationNotFoundError('message')),
+        },
+      },
+      preHandler: [requireLogin('mark private message read')],
+    },
+    async ({ auth, params: { msgID } }) => {
+      await markConversationReadByMessageID(auth.userID, msgID);
+      return {};
+    },
+  );
+
+  app.delete(
+    '/pm/conversations/:msgID',
+    {
+      schema: {
+        summary: '删除私信会话',
+        description: '仅对当前用户软删除，不影响会话对方',
+        operationId: 'deletePrivateMessageConversation',
+        tags: [Tag.Pm],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          msgID: t.Integer(),
+        }),
+        response: {
+          200: t.Object({}),
+          ...res.errorResponses(PmConversationNotFoundError('message')),
+        },
+      },
+      preHandler: [requireLogin('delete private message conversation')],
+    },
+    async ({ auth, params: { msgID } }) => {
+      await deleteConversation(auth.userID, msgID);
+      return {};
+    },
+  );
+
+  app.delete(
+    '/pm/:msgID',
+    {
+      schema: {
+        summary: '删除单条私信',
+        description: '仅对当前用户软删除，不影响对方',
+        operationId: 'deletePrivateMessage',
+        tags: [Tag.Pm],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          msgID: t.Integer(),
+        }),
+        response: {
+          200: t.Object({}),
+          ...res.errorResponses(PmConversationNotFoundError('message')),
+        },
+      },
+      preHandler: [requireLogin('delete private message')],
+    },
+    async ({ auth, params: { msgID } }) => {
+      await deleteMessage(auth.userID, msgID);
+      return {};
+    },
+  );
+}

--- a/routes/schemas.ts
+++ b/routes/schemas.ts
@@ -35,6 +35,7 @@ function addRequestSchemas(app: App) {
   app.addSchema(req.CreateContent);
   app.addSchema(req.CreateIndex);
   app.addSchema(req.CreateIndexRelated);
+  app.addSchema(req.CreatePrivateMessage);
   app.addSchema(req.CreateReply);
   app.addSchema(req.CreateReport);
   app.addSchema(req.CreateTopic);
@@ -96,6 +97,11 @@ function addResponseSchemas(app: App) {
   app.addSchema(res.PersonWikiInfo);
   app.addSchema(res.PersonWork);
   app.addSchema(res.Post);
+  app.addSchema(res.PrivateMessage);
+  app.addSchema(res.PrivateMessageContact);
+  app.addSchema(res.PrivateMessageConversation);
+  app.addSchema(res.PrivateMessageConversationDetail);
+  app.addSchema(res.PrivateMessageStatus);
   app.addSchema(res.Profile);
   app.addSchema(res.Reaction);
   app.addSchema(res.Reply);


### PR DESCRIPTION
## 概述

新增私信（PM）REST API，覆盖发送/回复、会话列表、详情、已读、删除等能力，并接入 socket 推送与发送限流。

## 端点

- `GET /pm` 邮箱状态（inbox / outbox / unread 计数）
- `POST /pm` 发送私信 / 回复
- `GET /pm/inbox` / `GET /pm/outbox` 会话列表（分页）
- `GET /pm/contacts` 最近联系人（15 个）
- `GET /pm/conversations/:msgID` 会话详情
- `PUT /pm/conversations/:msgID/read` 标记会话已读
- `DELETE /pm/conversations/:msgID` 删除会话（仅当前用户软删除）
- `DELETE /pm/:msgID` 删除单条消息（仅当前用户软删除）

## 关键行为

- **稳定错误码**：`PM_SEND_BANNED` / `PM_SEND_NOT_ALLOWED` / `PM_RECEIVER_NOT_FOUND` / `PM_SEND_SELF` / `PM_TOO_MANY_RECEIVERS` / `PM_CONTENT_INVALID` / `PM_CONVERSATION_NOT_FOUND`，前端按 `code` 映射文案，`message` 仅兜底。
- **`GET /pm/conversations/:msgID` 无自动已读副作用**，已读需显式调用 `PUT .../read`（避免 SWR revalidate 误标已读）。
- **收件人二选一**：`receivers`（username 列表）与 `receiverIDs`（user id 列表）必须且只能提供一个，去重后上限 10。
- **群发原子性**：任一收件人被拒（拉黑 / 隐私 none / 隐私 friends），整体返回 403 `PM_SEND_NOT_ALLOWED`，不发送任何消息；有意不区分具体收件人，保护对方隐私设置。
- **socket `pm` 事件**：载荷 `{ msgID, related, count }`，`count` 为接收者未读私信总数，供前端实时更新未读角标。
- **发送限流**：1 分钟 60 次（`LimitAction.Pm`）。

## 测试

- `routes/private/routes/pm.test.ts`：路由端到端测试（发送/回复/列表/详情/已读/删除/状态/联系人，含隐私、拉黑、群发原子失败等场景）
- `lib/pm/utils.test.ts`：`toPrivateMessage` / `canSendPM` 单元测试

本地验证：`tsc` 通过、`eslint` 通过、`prettier` 通过（提交时 lint-staged 已跑）；pm 测试依赖 MySQL/Redis，交由 CI 运行。
