### PR TITLE
feat: add rakuen topics aggregation API

### DIFF
--- a/lib/openapi/index.ts
+++ b/lib/openapi/index.ts
@@ -11,6 +11,7 @@ export const Tag = {
   Home: 'home',
   Index: 'index',
   Person: 'person',
+  RaKuen: 'rakuen',
   Relationship: 'relationship',
   Search: 'search',
   Subject: 'subject',

--- a/lib/rakuen/index.ts
+++ b/lib/rakuen/index.ts
@@ -25,11 +25,12 @@ interface QueryResult {
 }
 
 async function fetchGroupTopics(
-  auth: Readonly<IAuth>,
+  allowNsfw: boolean,
   limit: number,
   myGroup: boolean,
+  userID: number,
 ): Promise<QueryResult> {
-  if (myGroup && !auth.login) {
+  if (myGroup && userID === 0) {
     return { items: [], total: 0 };
   }
 
@@ -37,11 +38,11 @@ async function fetchGroupTopics(
     op.eq(schema.chiiGroupTopics.display, TopicDisplay.Normal),
     op.inArray(schema.chiiGroupTopics.state, PublicTopicStates),
   ];
-  if (!auth.allowNsfw) {
+  if (!allowNsfw) {
     conditions.push(op.eq(schema.chiiGroups.nsfw, false));
   }
   if (myGroup) {
-    const gids = await fetchJoinedGroups(auth.userID);
+    const gids = await fetchJoinedGroups(userID);
     if (gids.length === 0) {
       return { items: [], total: 0 };
     }
@@ -65,7 +66,7 @@ async function fetchGroupTopics(
   const [groups, users] = await Promise.all([
     fetcher.fetchSlimGroupsByIDs(
       data.map((d) => d.chii_group_topics.gid),
-      auth.allowNsfw,
+      allowNsfw,
     ),
     fetcher.fetchSlimUsersByIDs(data.map((d) => d.chii_group_topics.uid)),
   ]);
@@ -90,13 +91,13 @@ async function fetchGroupTopics(
   return { items, total: count };
 }
 
-async function fetchSubjectTopics(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
+async function fetchSubjectTopics(allowNsfw: boolean, limit: number): Promise<QueryResult> {
   const conditions = [
     op.eq(schema.chiiSubjectTopics.display, TopicDisplay.Normal),
     op.inArray(schema.chiiSubjectTopics.state, PublicTopicStates),
     op.ne(schema.chiiSubjects.ban, 1),
   ];
-  if (!auth.allowNsfw) {
+  if (!allowNsfw) {
     conditions.push(op.eq(schema.chiiSubjects.nsfw, false));
   }
   const join = op.eq(schema.chiiSubjectTopics.subjectID, schema.chiiSubjects.id);
@@ -117,7 +118,7 @@ async function fetchSubjectTopics(auth: Readonly<IAuth>, limit: number): Promise
     fetcher.fetchSlimUsersByIDs(data.map((d) => d.chii_subject_topics.uid)),
     fetcher.fetchSlimSubjectsByIDs(
       data.map((d) => d.chii_subject_topics.subjectID),
-      auth.allowNsfw,
+      allowNsfw,
     ),
   ]);
   const items: RaKuenItem[] = [];
@@ -141,13 +142,13 @@ async function fetchSubjectTopics(auth: Readonly<IAuth>, limit: number): Promise
   return { items, total: count };
 }
 
-async function fetchEpisodes(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
+async function fetchEpisodes(allowNsfw: boolean, limit: number): Promise<QueryResult> {
   const conditions = [
     op.ne(schema.chiiEpisodes.ban, 1),
     op.gt(schema.chiiEpisodes.comment, 0),
     op.ne(schema.chiiSubjects.ban, 1),
   ];
-  if (!auth.allowNsfw) {
+  if (!allowNsfw) {
     conditions.push(op.eq(schema.chiiSubjects.nsfw, false));
   }
   const join = op.eq(schema.chiiEpisodes.subjectID, schema.chiiSubjects.id);
@@ -166,7 +167,7 @@ async function fetchEpisodes(auth: Readonly<IAuth>, limit: number): Promise<Quer
 
   const subjects = await fetcher.fetchSlimSubjectsByIDs(
     data.map((d) => d.chii_episodes.subjectID),
-    auth.allowNsfw,
+    allowNsfw,
   );
   const items: RaKuenItem[] = [];
   for (const d of data) {
@@ -193,13 +194,13 @@ async function fetchEpisodes(auth: Readonly<IAuth>, limit: number): Promise<Quer
   return { items, total: count };
 }
 
-async function fetchCharacters(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
+async function fetchCharacters(allowNsfw: boolean, limit: number): Promise<QueryResult> {
   const conditions = [
     op.ne(schema.chiiCharacters.ban, 1),
     op.eq(schema.chiiCharacters.redirect, 0),
     op.gt(schema.chiiCharacters.comment, 0),
   ];
-  if (!auth.allowNsfw) {
+  if (!allowNsfw) {
     conditions.push(op.eq(schema.chiiCharacters.nsfw, false));
   }
   const [{ count = 0 } = {}] = await db
@@ -215,7 +216,7 @@ async function fetchCharacters(auth: Readonly<IAuth>, limit: number): Promise<Qu
 
   const slims = await fetcher.fetchSlimCharactersByIDs(
     data.map((d) => d.id),
-    auth.allowNsfw,
+    allowNsfw,
   );
   const items: RaKuenItem[] = [];
   for (const d of data) {
@@ -236,13 +237,13 @@ async function fetchCharacters(auth: Readonly<IAuth>, limit: number): Promise<Qu
   return { items, total: count };
 }
 
-async function fetchPersons(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
+async function fetchPersons(allowNsfw: boolean, limit: number): Promise<QueryResult> {
   const conditions = [
     op.ne(schema.chiiPersons.ban, 1),
     op.eq(schema.chiiPersons.redirect, 0),
     op.gt(schema.chiiPersons.comment, 0),
   ];
-  if (!auth.allowNsfw) {
+  if (!allowNsfw) {
     conditions.push(op.eq(schema.chiiPersons.nsfw, false));
   }
   const [{ count = 0 } = {}] = await db
@@ -258,7 +259,7 @@ async function fetchPersons(auth: Readonly<IAuth>, limit: number): Promise<Query
 
   const slims = await fetcher.fetchSlimPersonsByIDs(
     data.map((d) => d.id),
-    auth.allowNsfw,
+    allowNsfw,
   );
   const items: RaKuenItem[] = [];
   for (const d of data) {
@@ -298,11 +299,11 @@ export async function getRaKuenTopics(
   switch (type) {
     case IRaKuenTopicType.All: {
       const [g, s, e, c, p] = await Promise.all([
-        fetchGroupTopics(auth, limit, false),
-        fetchSubjectTopics(auth, limit),
-        fetchEpisodes(auth, limit),
-        fetchCharacters(auth, limit),
-        fetchPersons(auth, limit),
+        fetchGroupTopics(auth.allowNsfw, limit, false, auth.userID),
+        fetchSubjectTopics(auth.allowNsfw, limit),
+        fetchEpisodes(auth.allowNsfw, limit),
+        fetchCharacters(auth.allowNsfw, limit),
+        fetchPersons(auth.allowNsfw, limit),
       ]);
       result = {
         data: [...g.items, ...s.items, ...e.items, ...c.items, ...p.items]
@@ -313,32 +314,32 @@ export async function getRaKuenTopics(
       break;
     }
     case IRaKuenTopicType.Group: {
-      const { items, total } = await fetchGroupTopics(auth, limit, false);
+      const { items, total } = await fetchGroupTopics(auth.allowNsfw, limit, false, auth.userID);
       result = { data: items, total };
       break;
     }
     case IRaKuenTopicType.MyGroup: {
-      const { items, total } = await fetchGroupTopics(auth, limit, true);
+      const { items, total } = await fetchGroupTopics(auth.allowNsfw, limit, true, auth.userID);
       result = { data: items, total };
       break;
     }
     case IRaKuenTopicType.Subject: {
-      const { items, total } = await fetchSubjectTopics(auth, limit);
+      const { items, total } = await fetchSubjectTopics(auth.allowNsfw, limit);
       result = { data: items, total };
       break;
     }
     case IRaKuenTopicType.Episode: {
-      const { items, total } = await fetchEpisodes(auth, limit);
+      const { items, total } = await fetchEpisodes(auth.allowNsfw, limit);
       result = { data: items, total };
       break;
     }
     case IRaKuenTopicType.Character: {
-      const { items, total } = await fetchCharacters(auth, limit);
+      const { items, total } = await fetchCharacters(auth.allowNsfw, limit);
       result = { data: items, total };
       break;
     }
     case IRaKuenTopicType.Person: {
-      const { items, total } = await fetchPersons(auth, limit);
+      const { items, total } = await fetchPersons(auth.allowNsfw, limit);
       result = { data: items, total };
       break;
     }

--- a/lib/rakuen/index.ts
+++ b/lib/rakuen/index.ts
@@ -2,17 +2,20 @@ import { db, op, schema } from '@app/drizzle';
 import type { IAuth } from '@app/lib/auth/index.ts';
 import { TypedCache } from '@app/lib/cache.ts';
 import { BadRequestError } from '@app/lib/error';
-import { TopicDisplay } from '@app/lib/topic/type.ts';
+import { CommentState, TopicDisplay } from '@app/lib/topic/type.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
 import { IRaKuenTopicType } from '@app/lib/types/req.ts';
 import type * as res from '@app/lib/types/res.ts';
 import { fetchJoinedGroups } from '@app/lib/user/utils.ts';
 
-/** 全站 1 分钟缓存，my_group 为登录态数据，key 带 uid */
+/** 全站 1 分钟缓存，key 带 type/uid/nsfw/limit */
 const cache = TypedCache<string, res.IPaged<res.IRaKuenTopic>>(
   (key) => `rakuen:topics:v1:${key}`,
   60,
 );
+
+/** 聚合对登录/未登录共享缓存，统一使用匿名用户可见的话题状态 */
+const PublicTopicStates = [CommentState.Normal, CommentState.AdminReopen];
 
 type RaKuenItem = res.IRaKuenTopic;
 
@@ -30,7 +33,10 @@ async function fetchGroupTopics(
     return { items: [], total: 0 };
   }
 
-  const conditions = [op.eq(schema.chiiGroupTopics.display, TopicDisplay.Normal)];
+  const conditions = [
+    op.eq(schema.chiiGroupTopics.display, TopicDisplay.Normal),
+    op.inArray(schema.chiiGroupTopics.state, PublicTopicStates),
+  ];
   if (!auth.allowNsfw) {
     conditions.push(op.eq(schema.chiiGroups.nsfw, false));
   }
@@ -85,7 +91,11 @@ async function fetchGroupTopics(
 }
 
 async function fetchSubjectTopics(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
-  const conditions = [op.eq(schema.chiiSubjectTopics.display, TopicDisplay.Normal)];
+  const conditions = [
+    op.eq(schema.chiiSubjectTopics.display, TopicDisplay.Normal),
+    op.inArray(schema.chiiSubjectTopics.state, PublicTopicStates),
+    op.ne(schema.chiiSubjects.ban, 1),
+  ];
   if (!auth.allowNsfw) {
     conditions.push(op.eq(schema.chiiSubjects.nsfw, false));
   }
@@ -132,7 +142,11 @@ async function fetchSubjectTopics(auth: Readonly<IAuth>, limit: number): Promise
 }
 
 async function fetchEpisodes(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
-  const conditions = [op.ne(schema.chiiEpisodes.ban, 1)];
+  const conditions = [
+    op.ne(schema.chiiEpisodes.ban, 1),
+    op.gt(schema.chiiEpisodes.comment, 0),
+    op.ne(schema.chiiSubjects.ban, 1),
+  ];
   if (!auth.allowNsfw) {
     conditions.push(op.eq(schema.chiiSubjects.nsfw, false));
   }
@@ -183,6 +197,7 @@ async function fetchCharacters(auth: Readonly<IAuth>, limit: number): Promise<Qu
   const conditions = [
     op.ne(schema.chiiCharacters.ban, 1),
     op.eq(schema.chiiCharacters.redirect, 0),
+    op.gt(schema.chiiCharacters.comment, 0),
   ];
   if (!auth.allowNsfw) {
     conditions.push(op.eq(schema.chiiCharacters.nsfw, false));
@@ -222,7 +237,11 @@ async function fetchCharacters(auth: Readonly<IAuth>, limit: number): Promise<Qu
 }
 
 async function fetchPersons(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
-  const conditions = [op.ne(schema.chiiPersons.ban, 1), op.eq(schema.chiiPersons.redirect, 0)];
+  const conditions = [
+    op.ne(schema.chiiPersons.ban, 1),
+    op.eq(schema.chiiPersons.redirect, 0),
+    op.gt(schema.chiiPersons.comment, 0),
+  ];
   if (!auth.allowNsfw) {
     conditions.push(op.eq(schema.chiiPersons.nsfw, false));
   }
@@ -266,7 +285,9 @@ export async function getRaKuenTopics(
   limit: number,
 ): Promise<res.IPaged<res.IRaKuenTopic>> {
   const cacheKey =
-    type === IRaKuenTopicType.MyGroup ? `my_group:${auth.userID}:${limit}` : `${type}:${limit}`;
+    type === IRaKuenTopicType.MyGroup
+      ? `my_group:${auth.userID}:${auth.allowNsfw}:${limit}`
+      : `${type}:${auth.allowNsfw}:${limit}`;
 
   const cached = await cache.get(cacheKey);
   if (cached) {

--- a/lib/rakuen/index.ts
+++ b/lib/rakuen/index.ts
@@ -1,0 +1,331 @@
+import { db, op, schema } from '@app/drizzle';
+import type { IAuth } from '@app/lib/auth/index.ts';
+import { TypedCache } from '@app/lib/cache.ts';
+import { BadRequestError } from '@app/lib/error';
+import { TopicDisplay } from '@app/lib/topic/type.ts';
+import * as fetcher from '@app/lib/types/fetcher.ts';
+import { IRaKuenTopicType } from '@app/lib/types/req.ts';
+import type * as res from '@app/lib/types/res.ts';
+import { fetchJoinedGroups } from '@app/lib/user/utils.ts';
+
+/** 全站 1 分钟缓存，my_group 为登录态数据，key 带 uid */
+const cache = TypedCache<string, res.IPaged<res.IRaKuenTopic>>(
+  (key) => `rakuen:topics:v1:${key}`,
+  60,
+);
+
+type RaKuenItem = res.IRaKuenTopic;
+
+interface QueryResult {
+  items: RaKuenItem[];
+  total: number;
+}
+
+async function fetchGroupTopics(
+  auth: Readonly<IAuth>,
+  limit: number,
+  myGroup: boolean,
+): Promise<QueryResult> {
+  if (myGroup && !auth.login) {
+    return { items: [], total: 0 };
+  }
+
+  const conditions = [op.eq(schema.chiiGroupTopics.display, TopicDisplay.Normal)];
+  if (!auth.allowNsfw) {
+    conditions.push(op.eq(schema.chiiGroups.nsfw, false));
+  }
+  if (myGroup) {
+    const gids = await fetchJoinedGroups(auth.userID);
+    if (gids.length === 0) {
+      return { items: [], total: 0 };
+    }
+    conditions.push(op.inArray(schema.chiiGroupTopics.gid, gids));
+  }
+
+  const join = op.eq(schema.chiiGroupTopics.gid, schema.chiiGroups.id);
+  const [{ count = 0 } = {}] = await db
+    .select({ count: op.count() })
+    .from(schema.chiiGroupTopics)
+    .innerJoin(schema.chiiGroups, join)
+    .where(op.and(...conditions));
+  const data = await db
+    .select()
+    .from(schema.chiiGroupTopics)
+    .innerJoin(schema.chiiGroups, join)
+    .where(op.and(...conditions))
+    .orderBy(op.desc(schema.chiiGroupTopics.updatedAt))
+    .limit(limit);
+
+  const [groups, users] = await Promise.all([
+    fetcher.fetchSlimGroupsByIDs(
+      data.map((d) => d.chii_group_topics.gid),
+      auth.allowNsfw,
+    ),
+    fetcher.fetchSlimUsersByIDs(data.map((d) => d.chii_group_topics.uid)),
+  ]);
+  const items: RaKuenItem[] = [];
+  for (const d of data) {
+    const topic = d.chii_group_topics;
+    const group = groups[topic.gid];
+    const creator = users[topic.uid];
+    if (!group || !creator) {
+      continue;
+    }
+    items.push({
+      type: 'group',
+      id: topic.id,
+      title: topic.title,
+      replyCount: topic.replies,
+      creator,
+      group,
+      updatedAt: topic.updatedAt,
+    });
+  }
+  return { items, total: count };
+}
+
+async function fetchSubjectTopics(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
+  const conditions = [op.eq(schema.chiiSubjectTopics.display, TopicDisplay.Normal)];
+  if (!auth.allowNsfw) {
+    conditions.push(op.eq(schema.chiiSubjects.nsfw, false));
+  }
+  const join = op.eq(schema.chiiSubjectTopics.subjectID, schema.chiiSubjects.id);
+  const [{ count = 0 } = {}] = await db
+    .select({ count: op.count() })
+    .from(schema.chiiSubjectTopics)
+    .innerJoin(schema.chiiSubjects, join)
+    .where(op.and(...conditions));
+  const data = await db
+    .select()
+    .from(schema.chiiSubjectTopics)
+    .innerJoin(schema.chiiSubjects, join)
+    .where(op.and(...conditions))
+    .orderBy(op.desc(schema.chiiSubjectTopics.updatedAt))
+    .limit(limit);
+
+  const [users, subjects] = await Promise.all([
+    fetcher.fetchSlimUsersByIDs(data.map((d) => d.chii_subject_topics.uid)),
+    fetcher.fetchSlimSubjectsByIDs(
+      data.map((d) => d.chii_subject_topics.subjectID),
+      auth.allowNsfw,
+    ),
+  ]);
+  const items: RaKuenItem[] = [];
+  for (const d of data) {
+    const topic = d.chii_subject_topics;
+    const subject = subjects[topic.subjectID];
+    const creator = users[topic.uid];
+    if (!subject || !creator) {
+      continue;
+    }
+    items.push({
+      type: 'subject',
+      id: topic.id,
+      title: topic.title,
+      replyCount: topic.replies,
+      creator,
+      subject,
+      updatedAt: topic.updatedAt,
+    });
+  }
+  return { items, total: count };
+}
+
+async function fetchEpisodes(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
+  const conditions = [op.ne(schema.chiiEpisodes.ban, 1)];
+  if (!auth.allowNsfw) {
+    conditions.push(op.eq(schema.chiiSubjects.nsfw, false));
+  }
+  const join = op.eq(schema.chiiEpisodes.subjectID, schema.chiiSubjects.id);
+  const [{ count = 0 } = {}] = await db
+    .select({ count: op.count() })
+    .from(schema.chiiEpisodes)
+    .innerJoin(schema.chiiSubjects, join)
+    .where(op.and(...conditions));
+  const data = await db
+    .select()
+    .from(schema.chiiEpisodes)
+    .innerJoin(schema.chiiSubjects, join)
+    .where(op.and(...conditions))
+    .orderBy(op.desc(schema.chiiEpisodes.updatedAt))
+    .limit(limit);
+
+  const subjects = await fetcher.fetchSlimSubjectsByIDs(
+    data.map((d) => d.chii_episodes.subjectID),
+    auth.allowNsfw,
+  );
+  const items: RaKuenItem[] = [];
+  for (const d of data) {
+    const ep = d.chii_episodes;
+    const subject = subjects[ep.subjectID];
+    if (!subject) {
+      continue;
+    }
+    items.push({
+      type: 'episode',
+      id: ep.id,
+      subject,
+      episode: {
+        id: ep.id,
+        sort: ep.sort,
+        type: ep.type,
+        name: ep.name,
+        nameCN: ep.nameCN,
+        comment: ep.comment,
+      },
+      updatedAt: ep.updatedAt,
+    });
+  }
+  return { items, total: count };
+}
+
+async function fetchCharacters(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
+  const conditions = [
+    op.ne(schema.chiiCharacters.ban, 1),
+    op.eq(schema.chiiCharacters.redirect, 0),
+  ];
+  if (!auth.allowNsfw) {
+    conditions.push(op.eq(schema.chiiCharacters.nsfw, false));
+  }
+  const [{ count = 0 } = {}] = await db
+    .select({ count: op.count() })
+    .from(schema.chiiCharacters)
+    .where(op.and(...conditions));
+  const data = await db
+    .select({ id: schema.chiiCharacters.id, updatedAt: schema.chiiCharacters.lastPost })
+    .from(schema.chiiCharacters)
+    .where(op.and(...conditions))
+    .orderBy(op.desc(schema.chiiCharacters.lastPost))
+    .limit(limit);
+
+  const slims = await fetcher.fetchSlimCharactersByIDs(
+    data.map((d) => d.id),
+    auth.allowNsfw,
+  );
+  const items: RaKuenItem[] = [];
+  for (const d of data) {
+    const c = slims[d.id];
+    if (!c) {
+      continue;
+    }
+    items.push({
+      type: 'character',
+      id: c.id,
+      name: c.name,
+      nameCN: c.nameCN,
+      images: c.images,
+      comment: c.comment,
+      updatedAt: d.updatedAt,
+    });
+  }
+  return { items, total: count };
+}
+
+async function fetchPersons(auth: Readonly<IAuth>, limit: number): Promise<QueryResult> {
+  const conditions = [op.ne(schema.chiiPersons.ban, 1), op.eq(schema.chiiPersons.redirect, 0)];
+  if (!auth.allowNsfw) {
+    conditions.push(op.eq(schema.chiiPersons.nsfw, false));
+  }
+  const [{ count = 0 } = {}] = await db
+    .select({ count: op.count() })
+    .from(schema.chiiPersons)
+    .where(op.and(...conditions));
+  const data = await db
+    .select({ id: schema.chiiPersons.id, updatedAt: schema.chiiPersons.lastPost })
+    .from(schema.chiiPersons)
+    .where(op.and(...conditions))
+    .orderBy(op.desc(schema.chiiPersons.lastPost))
+    .limit(limit);
+
+  const slims = await fetcher.fetchSlimPersonsByIDs(
+    data.map((d) => d.id),
+    auth.allowNsfw,
+  );
+  const items: RaKuenItem[] = [];
+  for (const d of data) {
+    const p = slims[d.id];
+    if (!p) {
+      continue;
+    }
+    items.push({
+      type: 'person',
+      id: p.id,
+      name: p.name,
+      nameCN: p.nameCN,
+      images: p.images,
+      comment: p.comment,
+      updatedAt: d.updatedAt,
+    });
+  }
+  return { items, total: count };
+}
+
+export async function getRaKuenTopics(
+  auth: Readonly<IAuth>,
+  type: string,
+  limit: number,
+): Promise<res.IPaged<res.IRaKuenTopic>> {
+  const cacheKey =
+    type === IRaKuenTopicType.MyGroup ? `my_group:${auth.userID}:${limit}` : `${type}:${limit}`;
+
+  const cached = await cache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  let result: res.IPaged<res.IRaKuenTopic>;
+  switch (type) {
+    case IRaKuenTopicType.All: {
+      const [g, s, e, c, p] = await Promise.all([
+        fetchGroupTopics(auth, limit, false),
+        fetchSubjectTopics(auth, limit),
+        fetchEpisodes(auth, limit),
+        fetchCharacters(auth, limit),
+        fetchPersons(auth, limit),
+      ]);
+      result = {
+        data: [...g.items, ...s.items, ...e.items, ...c.items, ...p.items]
+          .toSorted((a, b) => b.updatedAt - a.updatedAt)
+          .slice(0, limit),
+        total: g.total + s.total + e.total + c.total + p.total,
+      };
+      break;
+    }
+    case IRaKuenTopicType.Group: {
+      const { items, total } = await fetchGroupTopics(auth, limit, false);
+      result = { data: items, total };
+      break;
+    }
+    case IRaKuenTopicType.MyGroup: {
+      const { items, total } = await fetchGroupTopics(auth, limit, true);
+      result = { data: items, total };
+      break;
+    }
+    case IRaKuenTopicType.Subject: {
+      const { items, total } = await fetchSubjectTopics(auth, limit);
+      result = { data: items, total };
+      break;
+    }
+    case IRaKuenTopicType.Episode: {
+      const { items, total } = await fetchEpisodes(auth, limit);
+      result = { data: items, total };
+      break;
+    }
+    case IRaKuenTopicType.Character: {
+      const { items, total } = await fetchCharacters(auth, limit);
+      result = { data: items, total };
+      break;
+    }
+    case IRaKuenTopicType.Person: {
+      const { items, total } = await fetchPersons(auth, limit);
+      result = { data: items, total };
+      break;
+    }
+    default: {
+      throw new BadRequestError(`invalid rakuen topic type ${type}`);
+    }
+  }
+
+  await cache.set(cacheKey, result);
+  return result;
+}

--- a/lib/types/req.ts
+++ b/lib/types/req.ts
@@ -83,6 +83,34 @@ export const GroupSort = t.String({
   - updated = 最新讨论`,
 });
 
+export const RaKuenTopicType = t.String({
+  $id: 'RaKuenTopicType',
+  enum: ['all', 'group', 'my_group', 'subject', 'episode', 'character', 'person'],
+  'x-ms-enum': {
+    name: 'RaKuenTopicType',
+    modelAsString: true,
+  },
+  'x-enum-varnames': ['All', 'Group', 'MyGroup', 'Subject', 'Episode', 'Character', 'Person'],
+  description: `超展开聚合类型
+  - all = 全部
+  - group = 小组话题
+  - my_group = 已加入小组的话题（未登录返回空）
+  - subject = 条目话题
+  - episode = 章节
+  - character = 角色
+  - person = 人物`,
+});
+
+export const IRaKuenTopicType = Object.freeze({
+  All: 'all',
+  Group: 'group',
+  MyGroup: 'my_group',
+  Subject: 'subject',
+  Episode: 'episode',
+  Character: 'character',
+  Person: 'person',
+});
+
 export const SubjectBrowseSort = t.String({
   $id: 'SubjectBrowseSort',
   enum: ['rank', 'trends', 'collects', 'date', 'title'],

--- a/lib/types/res.ts
+++ b/lib/types/res.ts
@@ -1032,6 +1032,93 @@ export const SubjectTopic = t.Intersect(
   { $id: 'SubjectTopic', title: 'SubjectTopic' },
 );
 
+export type IRaKuenGroupTopic = Static<typeof RaKuenGroupTopic>;
+export const RaKuenGroupTopic = t.Object(
+  {
+    type: t.Literal('group'),
+    id: t.Integer(),
+    title: t.String(),
+    replyCount: t.Integer(),
+    creator: Ref(SlimUser),
+    group: Ref(SlimGroup),
+    updatedAt: t.Integer({ description: '最后回复时间，unix time stamp in seconds' }),
+  },
+  { $id: 'RaKuenGroupTopic', title: 'RaKuenGroupTopic' },
+);
+
+export type IRaKuenSubjectTopic = Static<typeof RaKuenSubjectTopic>;
+export const RaKuenSubjectTopic = t.Object(
+  {
+    type: t.Literal('subject'),
+    id: t.Integer(),
+    title: t.String(),
+    replyCount: t.Integer(),
+    creator: Ref(SlimUser),
+    subject: Ref(SlimSubject),
+    updatedAt: t.Integer({ description: '最后回复时间，unix time stamp in seconds' }),
+  },
+  { $id: 'RaKuenSubjectTopic', title: 'RaKuenSubjectTopic' },
+);
+
+export type IRaKuenEpisode = Static<typeof RaKuenEpisode>;
+export const RaKuenEpisode = t.Object(
+  {
+    type: t.Literal('episode'),
+    id: t.Integer(),
+    subject: Ref(SlimSubject),
+    episode: t.Object({
+      id: t.Integer(),
+      sort: t.Number(),
+      type: Ref(EpisodeType),
+      name: t.String(),
+      nameCN: t.String(),
+      comment: t.Integer(),
+    }),
+    updatedAt: t.Integer({ description: '最后回复时间，unix time stamp in seconds' }),
+  },
+  { $id: 'RaKuenEpisode', title: 'RaKuenEpisode' },
+);
+
+export type IRaKuenCharacter = Static<typeof RaKuenCharacter>;
+export const RaKuenCharacter = t.Object(
+  {
+    type: t.Literal('character'),
+    id: t.Integer(),
+    name: t.String(),
+    nameCN: t.String(),
+    images: t.Optional(Ref(PersonImages)),
+    comment: t.Integer(),
+    updatedAt: t.Integer({ description: '最后回复时间，unix time stamp in seconds' }),
+  },
+  { $id: 'RaKuenCharacter', title: 'RaKuenCharacter' },
+);
+
+export type IRaKuenPerson = Static<typeof RaKuenPerson>;
+export const RaKuenPerson = t.Object(
+  {
+    type: t.Literal('person'),
+    id: t.Integer(),
+    name: t.String(),
+    nameCN: t.String(),
+    images: t.Optional(Ref(PersonImages)),
+    comment: t.Integer(),
+    updatedAt: t.Integer({ description: '最后回复时间，unix time stamp in seconds' }),
+  },
+  { $id: 'RaKuenPerson', title: 'RaKuenPerson' },
+);
+
+export type IRaKuenTopic = Static<typeof RaKuenTopic>;
+export const RaKuenTopic = t.Union(
+  [
+    Ref(RaKuenGroupTopic),
+    Ref(RaKuenSubjectTopic),
+    Ref(RaKuenEpisode),
+    Ref(RaKuenCharacter),
+    Ref(RaKuenPerson),
+  ],
+  { $id: 'RaKuenTopic', title: 'RaKuenTopic' },
+);
+
 export type IIndexStats = Static<typeof IndexStats>;
 export const IndexStats = t.Object(
   {

--- a/openapi.json
+++ b/openapi.json
@@ -617,6 +617,16 @@
           }
         }
       },
+      "RaKuenTopicType": {
+        "type": "string",
+        "enum": ["all", "group", "my_group", "subject", "episode", "character", "person"],
+        "x-ms-enum": {
+          "name": "RaKuenTopicType",
+          "modelAsString": true
+        },
+        "x-enum-varnames": ["All", "Group", "MyGroup", "Subject", "Episode", "Character", "Person"],
+        "description": "超展开聚合类型\n  - all = 全部\n  - group = 小组话题\n  - my_group = 已加入小组的话题（未登录返回空）\n  - subject = 条目话题\n  - episode = 章节\n  - character = 角色\n  - person = 人物"
+      },
       "SearchCharacter": {
         "type": "object",
         "required": ["keyword"],
@@ -2153,6 +2163,191 @@
           }
         },
         "title": "Profile"
+      },
+      "RaKuenCharacter": {
+        "type": "object",
+        "required": ["type", "id", "name", "nameCN", "comment", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["character"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nameCN": {
+            "type": "string"
+          },
+          "images": {
+            "$ref": "#/components/schemas/PersonImages"
+          },
+          "comment": {
+            "type": "integer"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenCharacter"
+      },
+      "RaKuenEpisode": {
+        "type": "object",
+        "required": ["type", "id", "subject", "episode", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["episode"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/SlimSubject"
+          },
+          "episode": {
+            "type": "object",
+            "required": ["id", "sort", "type", "name", "nameCN", "comment"],
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "sort": {
+                "type": "number"
+              },
+              "type": {
+                "$ref": "#/components/schemas/EpisodeType"
+              },
+              "name": {
+                "type": "string"
+              },
+              "nameCN": {
+                "type": "string"
+              },
+              "comment": {
+                "type": "integer"
+              }
+            }
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenEpisode"
+      },
+      "RaKuenGroupTopic": {
+        "type": "object",
+        "required": ["type", "id", "title", "replyCount", "creator", "group", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["group"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "replyCount": {
+            "type": "integer"
+          },
+          "creator": {
+            "$ref": "#/components/schemas/SlimUser"
+          },
+          "group": {
+            "$ref": "#/components/schemas/SlimGroup"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenGroupTopic"
+      },
+      "RaKuenPerson": {
+        "type": "object",
+        "required": ["type", "id", "name", "nameCN", "comment", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["person"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nameCN": {
+            "type": "string"
+          },
+          "images": {
+            "$ref": "#/components/schemas/PersonImages"
+          },
+          "comment": {
+            "type": "integer"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenPerson"
+      },
+      "RaKuenSubjectTopic": {
+        "type": "object",
+        "required": ["type", "id", "title", "replyCount", "creator", "subject", "updatedAt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["subject"]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "replyCount": {
+            "type": "integer"
+          },
+          "creator": {
+            "$ref": "#/components/schemas/SlimUser"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/SlimSubject"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          }
+        },
+        "title": "RaKuenSubjectTopic"
+      },
+      "RaKuenTopic": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RaKuenGroupTopic"
+          },
+          {
+            "$ref": "#/components/schemas/RaKuenSubjectTopic"
+          },
+          {
+            "$ref": "#/components/schemas/RaKuenEpisode"
+          },
+          {
+            "$ref": "#/components/schemas/RaKuenCharacter"
+          },
+          {
+            "$ref": "#/components/schemas/RaKuenPerson"
+          }
+        ],
+        "title": "RaKuenTopic"
       },
       "Reaction": {
         "type": "object",
@@ -12216,6 +12411,77 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/rakuen/topics": {
+      "get": {
+        "operationId": "getRaKuenTopics",
+        "summary": "获取超展开聚合列表",
+        "tags": ["rakuen"],
+        "description": "按最后回复时间倒序聚合全站讨论（小组话题/条目话题/章节/角色/人物），type=my_group 时仅返回已加入小组的话题，未登录返回空数据。",
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/RaKuenTopicType"
+            },
+            "in": "query",
+            "name": "type",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 200
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "min 1, max 200"
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data", "total"],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RaKuenTopic"
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数"
+                    }
+                  }
                 }
               }
             }

--- a/routes/private/index.ts
+++ b/routes/private/index.ts
@@ -23,6 +23,7 @@ import * as misc from './routes/misc.ts';
 import * as passkey from './routes/passkey.ts';
 import * as person from './routes/person.ts';
 import * as privacy from './routes/privacy.ts';
+import * as rakuen from './routes/rakuen.ts';
 import * as friend from './routes/relationship.ts';
 import * as report from './routes/report.ts';
 import * as search from './routes/search.ts';
@@ -95,6 +96,7 @@ async function API(app: App) {
   await app.register(passkey.setup);
   await app.register(person.setup);
   await app.register(privacy.setup);
+  await app.register(rakuen.setup);
   await app.register(report.setup);
   await app.register(search.setup);
   await app.register(subject.setup);

--- a/routes/private/routes/rakuen.test.ts
+++ b/routes/private/routes/rakuen.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from 'vitest';
+
+import { createTestServer } from '@app/tests/utils.ts';
+
+import { setup } from './rakuen.ts';
+
+const topicTypes = ['group', 'subject', 'episode', 'character', 'person'];
+
+describe('rakuen', () => {
+  test('should get all topics, sorted by updatedAt desc', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { limit: '20' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(typeof body.total).toBe('number');
+    const updatedAts = body.data.map((x: { updatedAt: number }) => x.updatedAt);
+    expect([...updatedAts].toSorted((a, b) => b - a)).toEqual(updatedAts);
+    for (const item of body.data) {
+      expect(topicTypes).toContain(item.type);
+      expect(item.updatedAt).toEqual(expect.any(Number));
+    }
+  });
+
+  test('should get group topics', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'group', limit: '10' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(typeof body.total).toBe('number');
+    for (const item of body.data) {
+      expect(item).toMatchObject({
+        type: 'group',
+        id: expect.any(Number),
+        title: expect.any(String),
+        replyCount: expect.any(Number),
+        creator: expect.objectContaining({ id: expect.any(Number) }),
+        group: expect.objectContaining({ id: expect.any(Number) }),
+        updatedAt: expect.any(Number),
+      });
+    }
+  });
+
+  test('should get subject topics', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'subject', limit: '10' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(typeof body.total).toBe('number');
+    for (const item of body.data) {
+      expect(item).toMatchObject({
+        type: 'subject',
+        id: expect.any(Number),
+        title: expect.any(String),
+        replyCount: expect.any(Number),
+        creator: expect.objectContaining({ id: expect.any(Number) }),
+        subject: expect.objectContaining({ id: expect.any(Number) }),
+        updatedAt: expect.any(Number),
+      });
+    }
+  });
+
+  test('should get episodes', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'episode', limit: '10' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(typeof body.total).toBe('number');
+    for (const item of body.data) {
+      expect(item).toMatchObject({
+        type: 'episode',
+        id: expect.any(Number),
+        subject: expect.objectContaining({ id: expect.any(Number) }),
+        episode: {
+          id: expect.any(Number),
+          sort: expect.any(Number),
+          type: expect.any(Number),
+          name: expect.any(String),
+          nameCN: expect.any(String),
+          comment: expect.any(Number),
+        },
+        updatedAt: expect.any(Number),
+      });
+    }
+  });
+
+  test('should get characters', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'character', limit: '10' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(typeof body.total).toBe('number');
+    for (const item of body.data) {
+      expect(item).toMatchObject({
+        type: 'character',
+        id: expect.any(Number),
+        name: expect.any(String),
+        comment: expect.any(Number),
+        updatedAt: expect.any(Number),
+      });
+    }
+  });
+
+  test('should get persons', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'person', limit: '10' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(typeof body.total).toBe('number');
+    for (const item of body.data) {
+      expect(item).toMatchObject({
+        type: 'person',
+        id: expect.any(Number),
+        name: expect.any(String),
+        comment: expect.any(Number),
+        updatedAt: expect.any(Number),
+      });
+    }
+  });
+
+  test('my_group without login returns empty data', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'my_group' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ data: [], total: 0 });
+  });
+
+  test('my_group with login returns joined group topics', async () => {
+    const app = createTestServer({ auth: { userID: 382951, login: true } });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'my_group', limit: '10' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(typeof body.total).toBe('number');
+    for (const item of body.data) {
+      expect(item.type).toBe('group');
+      expect(item.group.id).toBe(4215);
+    }
+  });
+
+  test('should reject invalid type', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'invalid' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should reject limit above 200', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { limit: '201' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/routes/private/routes/rakuen.test.ts
+++ b/routes/private/routes/rakuen.test.ts
@@ -1,10 +1,33 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 
+import { db, op, schema } from '@app/drizzle';
+import redis from '@app/lib/redis.ts';
+import { CommentState } from '@app/lib/topic/type.ts';
 import { createTestServer } from '@app/tests/utils.ts';
 
 import { setup } from './rakuen.ts';
 
 const topicTypes = ['group', 'subject', 'episode', 'character', 'person'];
+
+// 回归测试插入的数据，统一清理
+const insertedTopicIDs: number[] = [];
+const insertedCharacterIDs: number[] = [];
+
+afterEach(async () => {
+  if (insertedTopicIDs.length > 0) {
+    await db
+      .delete(schema.chiiGroupTopics)
+      .where(op.inArray(schema.chiiGroupTopics.id, insertedTopicIDs));
+    insertedTopicIDs.length = 0;
+  }
+  if (insertedCharacterIDs.length > 0) {
+    await db
+      .delete(schema.chiiCharacters)
+      .where(op.inArray(schema.chiiCharacters.id, insertedCharacterIDs));
+    insertedCharacterIDs.length = 0;
+  }
+  await redis.flushdb();
+});
 
 describe('rakuen', () => {
   test('should get all topics, sorted by updatedAt desc', async () => {
@@ -197,5 +220,115 @@ describe('rakuen', () => {
       query: { limit: '201' },
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  test('should exclude non-public topic states from group aggregate', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const rows = [
+      {
+        id: 990001,
+        gid: 1,
+        uid: 382951,
+        title: 'rakuen-test-normal',
+        createdAt: now,
+        updatedAt: now,
+        replies: 1,
+        state: CommentState.Normal,
+        display: 1,
+      },
+      {
+        id: 990002,
+        gid: 1,
+        uid: 382951,
+        title: 'rakuen-test-closed',
+        createdAt: now,
+        updatedAt: now,
+        replies: 1,
+        state: CommentState.AdminCloseTopic,
+        display: 1,
+      },
+      {
+        id: 990003,
+        gid: 1,
+        uid: 382951,
+        title: 'rakuen-test-silent',
+        createdAt: now,
+        updatedAt: now,
+        replies: 1,
+        state: CommentState.AdminSilentTopic,
+        display: 1,
+      },
+    ];
+    await db.insert(schema.chiiGroupTopics).values(rows);
+    insertedTopicIDs.push(...rows.map((r) => r.id));
+
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'group', limit: '200' },
+    });
+    expect(res.statusCode).toBe(200);
+    const titles = res.json().data.map((x: { title: string }) => x.title);
+    expect(titles).toContain('rakuen-test-normal');
+    expect(titles).not.toContain('rakuen-test-closed');
+    expect(titles).not.toContain('rakuen-test-silent');
+  });
+
+  test('should isolate cache by nsfw permission', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await db.insert(schema.chiiCharacters).values({
+      id: 990001,
+      name: 'rakuen-test-nsfw',
+      role: 1,
+      infobox: '',
+      summary: '',
+      img: '',
+      comment: 1,
+      collects: 0,
+      createdAt: now,
+      lastPost: now,
+      lock: 0,
+      anidbImg: '',
+      anidbId: 0,
+      ban: 0,
+      redirect: 0,
+      nsfw: true,
+    });
+    insertedCharacterIDs.push(990001);
+
+    const restricted = createTestServer();
+    await restricted.register(setup);
+    const nsfw = createTestServer({ auth: { allowNsfw: true } });
+    await nsfw.register(setup);
+
+    const r1 = await restricted.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'character', limit: '200' },
+    });
+    expect(r1.statusCode).toBe(200);
+    const names1 = r1.json().data.map((x: { name: string }) => x.name);
+    expect(names1).not.toContain('rakuen-test-nsfw');
+
+    const r2 = await nsfw.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'character', limit: '200' },
+    });
+    expect(r2.statusCode).toBe(200);
+    const names2 = r2.json().data.map((x: { name: string }) => x.name);
+    expect(names2).toContain('rakuen-test-nsfw');
+
+    // 未开启 NSFW 的用户不应读到上一步 nsfw 权限建立的缓存
+    const r3 = await restricted.inject({
+      method: 'get',
+      url: '/rakuen/topics',
+      query: { type: 'character', limit: '200' },
+    });
+    expect(r3.statusCode).toBe(200);
+    const names3 = r3.json().data.map((x: { name: string }) => x.name);
+    expect(names3).not.toContain('rakuen-test-nsfw');
   });
 });

--- a/routes/private/routes/rakuen.ts
+++ b/routes/private/routes/rakuen.ts
@@ -1,0 +1,37 @@
+import t from 'typebox';
+
+import { Security, Tag } from '@app/lib/openapi/index.ts';
+import { getRaKuenTopics } from '@app/lib/rakuen/index.ts';
+import * as req from '@app/lib/types/req.ts';
+import * as res from '@app/lib/types/res.ts';
+import type { App } from '@app/routes/type.ts';
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function setup(app: App) {
+  app.get(
+    '/rakuen/topics',
+    {
+      schema: {
+        summary: '获取超展开聚合列表',
+        description:
+          '按最后回复时间倒序聚合全站讨论（小组话题/条目话题/章节/角色/人物），' +
+          'type=my_group 时仅返回已加入小组的话题，未登录返回空数据。',
+        operationId: 'getRaKuenTopics',
+        tags: [Tag.RaKuen],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        querystring: t.Object({
+          type: t.Optional(req.Ref(req.RaKuenTopicType, { default: 'all' })),
+          limit: t.Optional(
+            t.Integer({ default: 50, minimum: 1, maximum: 200, description: 'min 1, max 200' }),
+          ),
+        }),
+        response: {
+          200: res.Paged(res.Ref(res.RaKuenTopic)),
+        },
+      },
+    },
+    async ({ auth, query: { type = req.IRaKuenTopicType.All, limit = 50 } }) => {
+      return await getRaKuenTopics(auth, type, limit);
+    },
+  );
+}

--- a/routes/schemas.ts
+++ b/routes/schemas.ts
@@ -45,6 +45,7 @@ function addRequestSchemas(app: App) {
   app.addSchema(req.PersonCreate);
   app.addSchema(req.PersonEdit);
   app.addSchema(req.PersonSearchFilter);
+  app.addSchema(req.RaKuenTopicType);
   app.addSchema(req.SearchCharacter);
   app.addSchema(req.SearchPerson);
   app.addSchema(req.SearchSubject);
@@ -97,6 +98,12 @@ function addResponseSchemas(app: App) {
   app.addSchema(res.PersonWork);
   app.addSchema(res.Post);
   app.addSchema(res.Profile);
+  app.addSchema(res.RaKuenCharacter);
+  app.addSchema(res.RaKuenEpisode);
+  app.addSchema(res.RaKuenGroupTopic);
+  app.addSchema(res.RaKuenPerson);
+  app.addSchema(res.RaKuenSubjectTopic);
+  app.addSchema(res.RaKuenTopic);
   app.addSchema(res.Reaction);
   app.addSchema(res.Reply);
   app.addSchema(res.ReplyBase);


### PR DESCRIPTION
Implements the backend API for the new frontend 超展开 (rakuen) page, per the agreed API design between server-private and frontend agents (requirements doc exchanged during multi-agent collaboration).

## API

`GET /p1/rakuen/topics` — aggregates the latest discussions across the whole site, sorted by last reply time (`updatedAt`, unix seconds) descending.

- `type`: `all` (default) | `group` | `my_group` | `subject` | `episode` | `character` | `person`; invalid value → 400
- `limit`: 1–200, default 50, no offset
- Response: `{ data: RaKuenTopic[], total: number }` (existing `Paged` wrapper); `RaKuenTopic` is a discriminated union keyed by `type`
- Login-agnostic: every type is anonymous-accessible; `my_group` returns `{ data: [], total: 0 }` when not logged in, so the frontend never branches on auth state
- Site-wide 1-minute Redis cache per `type+limit`; `my_group` is user-scoped (cache key includes uid)

## Data sources & filtering

| type | source | order | reply count | filters |
|---|---|---|---|---|
| group / my_group | `chii_group_topics` | `updatedAt` | `replies` | `display = 1`, group NSFW |
| subject | `chii_subject_topics` | `updatedAt` | `replies` | `display = 1`, subject NSFW |
| episode | `chii_episodes` | `updatedAt` | `comment` | `ban != 1`, subject NSFW |
| character | `chii_characters` | `lastPost` | `comment` | `ban != 1`, `redirect = 0`, NSFW |
| person | `chii_persons` | `lastPost` | `comment` | `ban != 1`, `redirect = 0`, NSFW |

`all` mode fetches `limit` rows per type and merges in memory (exact for global top-N); `total` is the exact sum of per-type counts.

## Files

- `lib/types/req.ts` — `RaKuenTopicType` schema + `IRaKuenTopicType` constants
- `lib/types/res.ts` — `RaKuenGroupTopic/SubjectTopic/Episode/Character/Person` + `RaKuenTopic` union
- `lib/rakuen/index.ts` (new) — queries, merge, cache
- `routes/private/routes/rakuen.ts` + `rakuen.test.ts` (new, 10 tests)
- `routes/schemas.ts`, `routes/private/index.ts`, `lib/openapi/index.ts`, `openapi.json` (regenerated)

## Tests

`pnpm tsc` ✅, `pnpm eslint` ✅, full suite `pnpm test` 434 passed ✅ (includes 10 new rakuen tests covering all types, my_group login/anon, invalid type 400, limit>200 400).

Frontend PR (UI + client generation from `openapi.json`): https://github.com/bangumi/frontend/pull/1046