### PR TITLE
feat(api): add index list API

### DIFF
--- a/bin/export-openapi.ts
+++ b/bin/export-openapi.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import * as lodash from 'lodash-es';
+import { format, resolveConfig } from 'prettier';
 
 import { projectRoot } from '@app/lib/config.ts';
 import { createServer } from '@app/lib/server.ts';
@@ -9,7 +10,10 @@ import { createServer } from '@app/lib/server.ts';
 const app = await createServer();
 
 const pri = await app.inject('/p1/openapi.json');
-await fs.writeFile(
-  path.resolve(projectRoot, 'openapi.json'),
-  JSON.stringify(lodash.omit(JSON.parse(pri.body), 'info.version'), null, 2),
-);
+const outFile = path.resolve(projectRoot, 'openapi.json');
+
+const body = JSON.stringify(lodash.omit(JSON.parse(pri.body), 'info.version'), null, 2);
+const config = await resolveConfig(outFile);
+const output = await format(body, { ...config, parser: 'json' });
+
+await fs.writeFile(outFile, output);

--- a/openapi.json
+++ b/openapi.json
@@ -9621,6 +9621,96 @@
             }
           }
         }
+      },
+      "get": {
+        "operationId": "getIndexes",
+        "summary": "获取目录列表",
+        "tags": ["index"],
+        "description": "全站公开目录列表，支持排序、分页和类型过滤",
+        "parameters": [
+          {
+            "schema": {
+              "enum": ["hot", "latest"],
+              "default": "latest"
+            },
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "description": "排序方式：hot=按收藏数，latest=按创建时间"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/IndexType"
+            },
+            "in": "query",
+            "name": "type",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "max 100"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "description": "min 0"
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data", "total"],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Index"
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/p1/indexes/{indexID}": {

--- a/routes/index.test.ts
+++ b/routes/index.test.ts
@@ -21,7 +21,7 @@ test('should keep openapi spec up to date', async () => {
   if (!isDeepStrictEqual(generated, committed)) {
     throw new Error(
       'openapi.json is out of date with the current code. ' +
-        'Run `pnpm run file ./bin/export-openapi.ts && pnpm exec prettier --write openapi.json` to update it.',
+        'Run `pnpm run file ./bin/export-openapi.ts` to update it.',
     );
   }
 }, 15000);

--- a/routes/private/routes/index.test.ts
+++ b/routes/private/routes/index.test.ts
@@ -138,6 +138,115 @@ describe('index APIs', () => {
     });
   });
 
+  describe('GET /indexes', () => {
+    test('should return paginated list containing newly created index', async () => {
+      const app = createTestServer({
+        auth: { login: true, userID: TEST_USER_ID },
+      });
+      await app.register(setup);
+
+      const createRes = await app.inject({
+        method: 'post',
+        url: '/indexes',
+        payload: {
+          title: 'Listed Index',
+          desc: 'Listed description',
+        },
+      });
+      expect(createRes.statusCode).toBe(200);
+      const { id } = createRes.json();
+      createdIndexId = id;
+
+      const res = await app.inject({
+        method: 'get',
+        url: '/indexes?order=latest&limit=100',
+      });
+      expect(res.statusCode).toBe(200);
+      const data = res.json();
+      expect(data).toHaveProperty('total');
+      expect(typeof data.total).toBe('number');
+      expect(Array.isArray(data.data)).toBe(true);
+      expect(data.data.map((item: { id: number }) => item.id)).toContain(id);
+    });
+
+    test('should filter out private indexes', async () => {
+      const app = createTestServer({
+        auth: { login: true, userID: TEST_USER_ID },
+      });
+      await app.register(setup);
+
+      const createRes = await app.inject({
+        method: 'post',
+        url: '/indexes',
+        payload: {
+          title: 'Private Index',
+          desc: 'Private description',
+          private: true,
+        },
+      });
+      expect(createRes.statusCode).toBe(200);
+      const { id } = createRes.json();
+      createdIndexId = id;
+
+      const res = await app.inject({
+        method: 'get',
+        url: '/indexes?order=latest&limit=100',
+      });
+      expect(res.statusCode).toBe(200);
+      const data = res.json();
+      expect(data.data.map((item: { id: number }) => item.id)).not.toContain(id);
+    });
+
+    test('should sort by collects when order=hot', async () => {
+      const app = createTestServer({});
+      await app.register(setup);
+
+      const res = await app.inject({
+        method: 'get',
+        url: '/indexes?order=hot&limit=100',
+      });
+      expect(res.statusCode).toBe(200);
+      const data = res.json();
+      const collects = data.data.map((item: { collects: number }) => item.collects);
+      for (let i = 1; i < collects.length; i++) {
+        expect(collects[i]).toBeLessThanOrEqual(collects[i - 1]);
+      }
+    });
+
+    test('should filter by type', async () => {
+      const app = createTestServer({
+        auth: { login: true, userID: TEST_USER_ID },
+      });
+      await app.register(setup);
+
+      const createRes = await app.inject({
+        method: 'post',
+        url: '/indexes',
+        payload: {
+          title: 'Type Filtered Index',
+          desc: 'Type filtered description',
+        },
+      });
+      expect(createRes.statusCode).toBe(200);
+      const { id } = createRes.json();
+      createdIndexId = id;
+
+      const type0Res = await app.inject({
+        method: 'get',
+        url: '/indexes?type=0&order=latest&limit=100',
+      });
+      expect(type0Res.statusCode).toBe(200);
+      expect(type0Res.json().data.map((item: { id: number }) => item.id)).toContain(id);
+
+      const type2Res = await app.inject({
+        method: 'get',
+        url: '/indexes?type=2&order=latest&limit=100',
+      });
+      expect(type2Res.statusCode).toBe(200);
+      expect(type2Res.json().data.map((item: { id: number }) => item.id)).not.toContain(id);
+    });
+  });
+
   describe('PATCH /indexes/:indexID', () => {
     test('should update index successfully', async () => {
       const app = createTestServer({

--- a/routes/private/routes/index.ts
+++ b/routes/private/routes/index.ts
@@ -68,6 +68,70 @@ export async function setup(app: App) {
   );
 
   app.get(
+    '/indexes',
+    {
+      schema: {
+        summary: '获取目录列表',
+        description: '全站公开目录列表，支持排序、分页和类型过滤',
+        operationId: 'getIndexes',
+        tags: [Tag.Index],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        querystring: t.Object({
+          order: t.Optional(
+            t.Enum(
+              { hot: 'hot', latest: 'latest' },
+              { default: 'latest', description: '排序方式：hot=按收藏数，latest=按创建时间' },
+            ),
+          ),
+          type: t.Optional(req.Ref(req.IndexType)),
+          limit: t.Optional(
+            t.Integer({ default: 20, minimum: 1, maximum: 100, description: 'max 100' }),
+          ),
+          offset: t.Optional(t.Integer({ default: 0, minimum: 0, description: 'min 0' })),
+        }),
+        response: {
+          200: res.Paged(res.Ref(res.Index)),
+        },
+      },
+    },
+    async ({ query: { order = 'latest', type, limit = 20, offset = 0 } }) => {
+      const conditions = [op.eq(schema.chiiIndexes.ban, IndexPrivacy.Normal)];
+      if (type !== undefined) {
+        conditions.push(op.eq(schema.chiiIndexes.type, type));
+      }
+
+      const [{ count = 0 } = {}] = await db
+        .select({ count: op.count() })
+        .from(schema.chiiIndexes)
+        .where(op.and(...conditions));
+
+      const orderBy =
+        order === 'hot'
+          ? [op.desc(schema.chiiIndexes.collects), op.desc(schema.chiiIndexes.createdAt)]
+          : [op.desc(schema.chiiIndexes.createdAt)];
+
+      const data = await db
+        .select()
+        .from(schema.chiiIndexes)
+        .where(op.and(...conditions))
+        .orderBy(...orderBy)
+        .limit(limit)
+        .offset(offset);
+
+      const indexes = data.map((d) => convert.toIndex(d));
+      const users = await fetcher.fetchSlimUsersByIDs(indexes.map((i) => i.uid));
+      for (const index of indexes) {
+        index.user = users[index.uid];
+      }
+
+      return {
+        data: indexes,
+        total: count,
+      };
+    },
+  );
+
+  app.get(
     '/indexes/:indexID',
     {
       schema: {


### PR DESCRIPTION
## 目的

旧站有 `/index`（目录首页：热门/最新列表）和 `/index/browser`（目录浏览），新后端此前只有目录 CRUD、关联内容和评论接口，缺少目录列表接口，前端无法实现列表页。本次新增 `GET /indexes` 补全该能力，行为对齐旧站 `IndexCore::FetchIndexList`（首页最新/热门排序 + browser 分页浏览）。

## 变更

- **`routes/private/routes/index.ts`**：新增 `GET /indexes`（operationId `getIndexes`）
  - 请求参数（均可选）：`order`（`latest` 默认，按创建时间倒序；`hot` 按收藏数倒序，次级按创建时间保证稳定）、`type`（IndexType 过滤 0=用户/1=公共/2=TBA）、`limit`（默认 20，max 100）、`offset`（默认 0）
  - 过滤：仅返回公开目录（`ban = IndexPrivacy.Normal`），私密/封禁目录不返回，无需登录
  - 响应：`Paged<Index>` = `{ data: Index[], total }`，`Index` 含 `desc/collects/replies/stats/user` 等完整信息
- **`routes/private/routes/index.test.ts`**：新增 4 个用例（分页包含新建目录、私密目录过滤、`order=hot` 排序、`type` 过滤）
- **`openapi.json`**：重新生成（新增 `getIndexes` 路径及对应 schema）
- **`routes/index.test.ts`**：openapi 过期提示文案移除 prettier 步骤，与 `838d1b34`（生成脚本内置 prettier 格式化）配套

## 测试

`pnpm vitest run routes/private/routes/index.test.ts routes/index.test.ts` 全部通过（49 tests），`tsc` 与 `eslint` 无错误。