### PR TITLE
feat(api): add subject comment write APIs

### DIFF
--- a/lib/types/req.ts
+++ b/lib/types/req.ts
@@ -325,6 +325,24 @@ export const CollectSubject = t.Object(
   { $id: 'CollectSubject' },
 );
 
+export type ICreateSubjectComment = Static<typeof CreateSubjectComment>;
+export const CreateSubjectComment = t.Object(
+  {
+    comment: t.String({ minLength: 1, description: '吐槽内容' }),
+    type: t.Optional(Ref(CollectionType)),
+    rate: t.Optional(t.Integer({ minimum: 0, maximum: 10, description: '评分，0 表示删除评分' })),
+  },
+  { $id: 'CreateSubjectComment' },
+);
+
+export type IUpdateSubjectComment = Static<typeof UpdateSubjectComment>;
+export const UpdateSubjectComment = t.Object(
+  {
+    comment: t.String({ minLength: 1, description: '吐槽内容' }),
+  },
+  { $id: 'UpdateSubjectComment' },
+);
+
 export type IUpdateSubjectProgress = Static<typeof UpdateSubjectProgress>;
 export const UpdateSubjectProgress = t.Object(
   {

--- a/openapi.json
+++ b/openapi.json
@@ -457,6 +457,26 @@
         },
         "title": "CreateReport"
       },
+      "CreateSubjectComment": {
+        "type": "object",
+        "required": ["comment"],
+        "properties": {
+          "comment": {
+            "type": "string",
+            "minLength": 1,
+            "description": "吐槽内容"
+          },
+          "type": {
+            "$ref": "#/components/schemas/CollectionType"
+          },
+          "rate": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "description": "评分，0 表示删除评分"
+          }
+        }
+      },
       "CreateTopic": {
         "type": "object",
         "required": ["title", "content"],
@@ -810,6 +830,17 @@
           }
         },
         "title": "UpdateIndexRelated"
+      },
+      "UpdateSubjectComment": {
+        "type": "object",
+        "required": ["comment"],
+        "properties": {
+          "comment": {
+            "type": "string",
+            "minLength": 1,
+            "description": "吐槽内容"
+          }
+        }
       },
       "UpdateSubjectProgress": {
         "type": "object",
@@ -13689,6 +13720,303 @@
                       "description": "limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数"
                     }
                   }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createSubjectComment",
+        "summary": "发表条目的吐槽",
+        "tags": ["subject"],
+        "description": "吐槽挂在条目收藏上：已收藏则更新吐槽，未收藏需传 type 创建收藏并写吐槽",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateSubjectComment"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TurnstileToken"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "subjectID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id"],
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "new comment id"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/subjects/-/comments/{commentID}": {
+      "put": {
+        "operationId": "updateSubjectComment",
+        "summary": "编辑条目的吐槽",
+        "tags": ["subject"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSubjectComment"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "in": "path",
+            "name": "commentID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteSubjectComment",
+        "summary": "删除条目的吐槽",
+        "tags": ["subject"],
+        "description": "删除吐槽会清空吐槽内容并保留收藏记录",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "in": "path",
+            "name": "commentID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/subjects/-/comments/{commentID}/like": {
+      "put": {
+        "operationId": "likeSubjectComment",
+        "summary": "给条目的吐槽点赞",
+        "tags": ["subject"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["value"],
+                "properties": {
+                  "value": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "commentID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "unlikeSubjectComment",
+        "summary": "取消条目的吐槽点赞",
+        "tags": ["subject"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "commentID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
                 }
               }
             }

--- a/routes/private/routes/subject.test.ts
+++ b/routes/private/routes/subject.test.ts
@@ -1,8 +1,10 @@
-import { beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { db, op, schema } from '@app/drizzle';
 import { emptyAuth } from '@app/lib/auth/index.ts';
+import { LikeType } from '@app/lib/like';
 import redis from '@app/lib/redis.ts';
+import { CollectionType } from '@app/lib/subject/type.ts';
 import { CommentState } from '@app/lib/topic/type.ts';
 import { getFriendsCacheKey } from '@app/lib/user/cache.ts';
 import { createTestServer } from '@app/tests/utils.ts';
@@ -399,5 +401,288 @@ describe('subject topics', () => {
       .from(schema.chiiSubjectPosts)
       .where(op.eq(schema.chiiSubjectPosts.id, id));
     expect(deletedPost?.state).toBe(CommentState.UserDelete);
+  });
+});
+
+describe('subject comment write APIs', () => {
+  const TEST_USER_ID = 382951;
+  const TEST_COMMENT_ID = 1; // uid=382951, subjectID=8, hasComment=1
+  const OTHER_COMMENT_ID = 3; // uid=2703, subjectID=4, hasComment=0
+
+  async function reset() {
+    // 恢复 dist.sql 初始数据
+    await db
+      .update(schema.chiiSubjectInterests)
+      .set({
+        comment: 'test comment',
+        hasComment: 1,
+        rate: 0,
+        type: CollectionType.Collect,
+        privacy: 0,
+        updatedAt: 1639569371,
+      })
+      .where(op.eq(schema.chiiSubjectInterests.id, TEST_COMMENT_ID));
+    await db
+      .update(schema.chiiSubjectInterests)
+      .set({
+        comment: '',
+        hasComment: 0,
+        rate: 0,
+        type: CollectionType.Wish,
+        privacy: 0,
+        updatedAt: 1639569404,
+      })
+      .where(op.eq(schema.chiiSubjectInterests.id, 2));
+    await db
+      .update(schema.chiiSubjectInterests)
+      .set({
+        comment: '',
+        hasComment: 0,
+        rate: 0,
+        type: CollectionType.Wish,
+        privacy: 0,
+        updatedAt: 1639569404,
+      })
+      .where(op.eq(schema.chiiSubjectInterests.id, OTHER_COMMENT_ID));
+    // subject 12 创建路径清理
+    await db
+      .delete(schema.chiiSubjectInterests)
+      .where(
+        op.and(
+          op.eq(schema.chiiSubjectInterests.uid, TEST_USER_ID),
+          op.eq(schema.chiiSubjectInterests.subjectID, 12),
+        ),
+      );
+    await db
+      .update(schema.chiiSubjects)
+      .set({ collect: 4534, doing: 215 })
+      .where(op.eq(schema.chiiSubjects.id, 12));
+    await db
+      .update(schema.chiiSubjectFields)
+      .set({ rate10: 168 })
+      .where(op.eq(schema.chiiSubjectFields.id, 12));
+    // 清理吐槽点赞
+    await db
+      .delete(schema.chiiLikes)
+      .where(
+        op.and(
+          op.eq(schema.chiiLikes.type, LikeType.SubjectCollect),
+          op.inArray(schema.chiiLikes.relatedID, [TEST_COMMENT_ID, 2, OTHER_COMMENT_ID]),
+        ),
+      );
+  }
+
+  beforeEach(async () => {
+    await reset();
+  });
+
+  afterEach(async () => {
+    await reset();
+  });
+
+  test('should create subject comment on existing collection', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/4/comments',
+      payload: { comment: 'new comment', turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(200);
+    const { id } = res.json();
+    expect(id).toBe(2); // 已有收藏 id=2，更新吐槽
+    const [interest] = await db
+      .select()
+      .from(schema.chiiSubjectInterests)
+      .where(op.eq(schema.chiiSubjectInterests.id, 2));
+    expect(interest?.comment).toBe('new comment');
+    expect(interest?.hasComment).toBe(1);
+  });
+
+  test('should create subject comment with new collection', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/12/comments',
+      payload: {
+        comment: 'new comment',
+        type: CollectionType.Collect,
+        turnstileToken: 'fake-response',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const { id } = res.json();
+    expect(typeof id).toBe('number');
+    const [interest] = await db
+      .select()
+      .from(schema.chiiSubjectInterests)
+      .where(
+        op.and(
+          op.eq(schema.chiiSubjectInterests.uid, TEST_USER_ID),
+          op.eq(schema.chiiSubjectInterests.subjectID, 12),
+        ),
+      );
+    expect(interest?.comment).toBe('new comment');
+    expect(interest?.hasComment).toBe(1);
+    expect(interest?.type).toBe(CollectionType.Collect);
+    const [subject] = await db
+      .select()
+      .from(schema.chiiSubjects)
+      .where(op.eq(schema.chiiSubjects.id, 12));
+    expect(subject?.collect).toBe(4535);
+  });
+
+  test('should require type on new subject comment', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/12/comments',
+      payload: { comment: 'new comment', turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should not create subject comment without login', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/8/comments',
+      payload: { comment: 'new comment', turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('should update own subject comment', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'put',
+      url: `/subjects/-/comments/${TEST_COMMENT_ID}`,
+      payload: { comment: 'updated comment' },
+    });
+    expect(res.statusCode).toBe(200);
+    const [interest] = await db
+      .select()
+      .from(schema.chiiSubjectInterests)
+      .where(op.eq(schema.chiiSubjectInterests.id, TEST_COMMENT_ID));
+    expect(interest?.comment).toBe('updated comment');
+  });
+
+  test('should not update comment of others', async () => {
+    // 先把 OTHER_COMMENT_ID 变成"别人的吐槽"以覆盖权限分支
+    await db
+      .update(schema.chiiSubjectInterests)
+      .set({ comment: 'other comment', hasComment: 1 })
+      .where(op.eq(schema.chiiSubjectInterests.id, OTHER_COMMENT_ID));
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'put',
+      url: `/subjects/-/comments/${OTHER_COMMENT_ID}`,
+      payload: { comment: 'updated comment' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('should delete own subject comment', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'delete',
+      url: `/subjects/-/comments/${TEST_COMMENT_ID}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const [interest] = await db
+      .select()
+      .from(schema.chiiSubjectInterests)
+      .where(op.eq(schema.chiiSubjectInterests.id, TEST_COMMENT_ID));
+    expect(interest?.hasComment).toBe(0);
+    expect(interest?.comment).toBe('');
+  });
+
+  test('should not delete comment of others', async () => {
+    await db
+      .update(schema.chiiSubjectInterests)
+      .set({ comment: 'other comment', hasComment: 1 })
+      .where(op.eq(schema.chiiSubjectInterests.id, OTHER_COMMENT_ID));
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'delete',
+      url: `/subjects/-/comments/${OTHER_COMMENT_ID}`,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('should like subject comment', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'put',
+      url: `/subjects/-/comments/${TEST_COMMENT_ID}/like`,
+      payload: { value: 0 },
+    });
+    expect(res.statusCode).toBe(200);
+    const [like] = await db
+      .select()
+      .from(schema.chiiLikes)
+      .where(
+        op.and(
+          op.eq(schema.chiiLikes.type, LikeType.SubjectCollect),
+          op.eq(schema.chiiLikes.relatedID, TEST_COMMENT_ID),
+          op.eq(schema.chiiLikes.uid, TEST_USER_ID),
+        ),
+      );
+    expect(like?.deleted).toBe(false);
+  });
+
+  test('should unlike subject comment', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const likeRes = await app.inject({
+      method: 'put',
+      url: `/subjects/-/comments/${TEST_COMMENT_ID}/like`,
+      payload: { value: 0 },
+    });
+    expect(likeRes.statusCode).toBe(200);
+    const unlikeRes = await app.inject({
+      method: 'delete',
+      url: `/subjects/-/comments/${TEST_COMMENT_ID}/like`,
+    });
+    expect(unlikeRes.statusCode).toBe(200);
+    const [like] = await db
+      .select()
+      .from(schema.chiiLikes)
+      .where(
+        op.and(
+          op.eq(schema.chiiLikes.type, LikeType.SubjectCollect),
+          op.eq(schema.chiiLikes.relatedID, TEST_COMMENT_ID),
+          op.eq(schema.chiiLikes.uid, TEST_USER_ID),
+        ),
+      );
+    expect(like?.deleted).toBe(true);
   });
 });

--- a/routes/private/routes/subject.test.ts
+++ b/routes/private/routes/subject.test.ts
@@ -678,6 +678,85 @@ describe('subject comment write APIs', () => {
     expect(res.statusCode).toBe(403);
   });
 
+  test('should reject empty comment after trim', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/8/comments',
+      payload: { comment: ' '.repeat(3), turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should reject comment with invisible characters', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/8/comments',
+      payload: { comment: 'bad\u200Bword', turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should reject comment longer than 380 characters', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/8/comments',
+      payload: { comment: 'a'.repeat(381), turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should reject subject comment when user is banned', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: TEST_USER_ID,
+        permission: { ban_post: true },
+      },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/8/comments',
+      payload: { comment: 'new comment', turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('should restore shadow-banned comment to private on update', async () => {
+    await db
+      .update(schema.chiiSubjectInterests)
+      .set({ privacy: 2 })
+      .where(op.eq(schema.chiiSubjectInterests.id, TEST_COMMENT_ID));
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'put',
+      url: `/subjects/-/comments/${TEST_COMMENT_ID}`,
+      payload: { comment: 'clean text' },
+    });
+    expect(res.statusCode).toBe(200);
+    const [interest] = await db
+      .select()
+      .from(schema.chiiSubjectInterests)
+      .where(op.eq(schema.chiiSubjectInterests.id, TEST_COMMENT_ID));
+    expect(interest?.privacy).toBe(1); // ShadowBan 解除后恢复为仅自己可见
+  });
+
   test('should like subject comment', async () => {
     const app = createTestServer({
       auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },

--- a/routes/private/routes/subject.test.ts
+++ b/routes/private/routes/subject.test.ts
@@ -455,7 +455,7 @@ describe('subject comment write APIs', () => {
       );
     await db
       .update(schema.chiiSubjects)
-      .set({ collect: 4534, doing: 215 })
+      .set({ wish: 1159, collect: 4534, doing: 215 })
       .where(op.eq(schema.chiiSubjects.id, 12));
     await db
       .update(schema.chiiSubjectFields)
@@ -500,6 +500,51 @@ describe('subject comment write APIs', () => {
       .where(op.eq(schema.chiiSubjectInterests.id, 2));
     expect(interest?.comment).toBe('new comment');
     expect(interest?.hasComment).toBe(1);
+  });
+
+  test('should trim comment', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/4/comments',
+      payload: { comment: '  spaced comment  ', turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(200);
+    const [interest] = await db
+      .select()
+      .from(schema.chiiSubjectInterests)
+      .where(op.eq(schema.chiiSubjectInterests.id, 2));
+    expect(interest?.comment).toBe('spaced comment');
+  });
+
+  test('should force rate to 0 for wish collection', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: TEST_USER_ID },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/subjects/12/comments',
+      payload: {
+        comment: 'wish comment',
+        type: CollectionType.Wish,
+        rate: 5,
+        turnstileToken: 'fake-response',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const { id } = res.json();
+    const [interest] = await db
+      .select()
+      .from(schema.chiiSubjectInterests)
+      .where(op.eq(schema.chiiSubjectInterests.id, id));
+    expect(interest?.rate).toBe(0);
+    expect(interest?.type).toBe(CollectionType.Wish);
   });
 
   test('should create subject comment with new collection', async () => {

--- a/routes/private/routes/subject.ts
+++ b/routes/private/routes/subject.ts
@@ -31,6 +31,8 @@ import { requireLogin, requireTurnstileToken } from '@app/routes/hooks/pre-handl
 import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
+type SubjectInterestInsert = typeof schema.chiiSubjectInterests.$inferInsert;
+
 function toSubjectRelation(
   subject: orm.ISubject,
   fields: orm.ISubjectFields,
@@ -807,7 +809,7 @@ export async function setup(app: App) {
           if (effectiveType === CollectionType.Wish) {
             rate = 0;
           }
-          const toUpdate: Partial<orm.ISubjectInterest> = {
+          const toUpdate: Partial<SubjectInterestInsert> = {
             comment,
             hasComment: 1,
             updatedAt: now,
@@ -850,7 +852,7 @@ export async function setup(app: App) {
             privacy = CollectionPrivacy.Ban;
           }
           const field = getCollectionTypeField(type);
-          const toInsert: typeof schema.chiiSubjectInterests.$inferInsert = {
+          const toInsert: SubjectInterestInsert = {
             uid: auth.userID,
             subjectID,
             subjectType: subject.type,
@@ -951,7 +953,7 @@ export async function setup(app: App) {
       }
 
       await rateLimit(LimitAction.Comment, auth.userID);
-      const toUpdate: Partial<orm.ISubjectInterest> = {
+      const toUpdate: Partial<SubjectInterestInsert> = {
         comment: normalizedComment,
         updatedAt: DateTime.now().toUnixInteger(),
         updateIp: ip,

--- a/routes/private/routes/subject.ts
+++ b/routes/private/routes/subject.ts
@@ -11,7 +11,11 @@ import { Notify, NotifyType } from '@app/lib/notify.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
 import { getEpStatus } from '@app/lib/subject/ep';
 import type { SubjectFilter, SubjectSort } from '@app/lib/subject/type.ts';
-import { CollectionPrivacy, getCollectionTypeField } from '@app/lib/subject/type.ts';
+import {
+  CollectionPrivacy,
+  CollectionType,
+  getCollectionTypeField,
+} from '@app/lib/subject/type.ts';
 import { updateSubjectCollectionCounts, updateSubjectRating } from '@app/lib/subject/utils.ts';
 import { AsyncTimelineWriter } from '@app/lib/timeline/writer.ts';
 import { CanViewTopicContent, CanViewTopicReply } from '@app/lib/topic/display.ts';
@@ -755,18 +759,27 @@ export async function setup(app: App) {
         throw new NotFoundError(`subject ${subjectID}`);
       }
 
-      let comment = body.comment;
-      let rate = body.rate;
       const type = body.type;
+      let rate = body.rate;
 
-      comment = comment.normalize('NFC');
-      if (comment.length > 380) {
-        throw new BadRequestError('comment too long');
+      // 对齐 Go UpdateComment：NFC normalize → trim → 不可见字符检查 → 380 长度限制
+      const comment = body.comment.normalize('NFC').trim();
+      if (comment === '') {
+        throw new BadRequestError('comment is required');
+      }
+      if (!Dam.allCharacterPrintable(comment)) {
+        throw new BadRequestError('invisible character are included in comment');
+      }
+      if ([...comment].length > 380) {
+        throw new BadRequestError('comment too long, only allow less equal than 380 characters');
+      }
+      // 对齐 Go：被禁言用户不允许发表吐槽
+      if (auth.permission.ban_post) {
+        throw new NotAllowedError('create subject comment');
       }
 
       await rateLimit(LimitAction.Subject, auth.userID);
 
-      let needTimeline = false;
       let privacy: number = CollectionPrivacy.Public;
       let commentID = 0;
       const now = DateTime.now().toUnixInteger();
@@ -786,8 +799,14 @@ export async function setup(app: App) {
         }
         if (interest) {
           commentID = interest.id;
+          privacy = interest.privacy;
           const oldRate = interest.rate;
           const oldType = interest.type;
+          const effectiveType = type ?? oldType;
+          // 对齐 Go UpdateRate：想看状态时评分强制为 0
+          if (effectiveType === CollectionType.Wish) {
+            rate = 0;
+          }
           const toUpdate: Partial<orm.ISubjectInterest> = {
             comment,
             hasComment: 1,
@@ -795,7 +814,6 @@ export async function setup(app: App) {
             updateIp: ip,
           };
           if (type && oldType !== type) {
-            needTimeline = true;
             toUpdate.type = type;
             toUpdate[`${getCollectionTypeField(type)}Dateline`] = now;
             await updateSubjectCollectionCounts(t, subjectID, type, oldType);
@@ -803,9 +821,14 @@ export async function setup(app: App) {
           if (oldRate !== rate) {
             toUpdate.rate = rate;
           }
-          if (dam.needReview(comment) || auth.permission.ban_post) {
+          if (dam.needReview(comment)) {
+            // 对齐 Go ShadowBan：触发敏感词 → 禁止公开
             privacy = CollectionPrivacy.Ban;
             toUpdate.privacy = CollectionPrivacy.Ban;
+          } else if (interest.privacy === CollectionPrivacy.Ban) {
+            // 对齐 Go ShadowBan 解除：不再触发敏感词时恢复为仅自己可见
+            privacy = CollectionPrivacy.Private;
+            toUpdate.privacy = CollectionPrivacy.Private;
           }
           await t
             .update(schema.chiiSubjectInterests)
@@ -819,7 +842,11 @@ export async function setup(app: App) {
           if (!type) {
             throw new BadRequestError('type is required on new subject comment');
           }
-          if (dam.needReview(comment) || auth.permission.ban_post) {
+          // 对齐 Go UpdateRate：想看状态时评分强制为 0
+          if (type === CollectionType.Wish) {
+            rate = 0;
+          }
+          if (dam.needReview(comment)) {
             privacy = CollectionPrivacy.Ban;
           }
           const field = getCollectionTypeField(type);
@@ -847,7 +874,6 @@ export async function setup(app: App) {
           };
           const [result] = await t.insert(schema.chiiSubjectInterests).values(toInsert);
           commentID = result.insertId;
-          needTimeline = true;
           await updateSubjectCollectionCounts(t, subjectID, type);
           if (rate) {
             await updateSubjectRating(t, subjectID, 0, rate);
@@ -855,7 +881,8 @@ export async function setup(app: App) {
         }
       });
 
-      if (needTimeline && privacy === CollectionPrivacy.Public) {
+      // 对齐 Go mayCreateTimeline：请求带 type 且收藏公开时才写时间线
+      if (type !== undefined && privacy === CollectionPrivacy.Public) {
         await AsyncTimelineWriter.subject({
           uid: auth.userID,
           subject: {
@@ -864,7 +891,7 @@ export async function setup(app: App) {
           },
           collect: {
             id: commentID,
-            type: type ?? 0,
+            type,
             rate: rate ?? 0,
             comment,
           },
@@ -906,10 +933,21 @@ export async function setup(app: App) {
       if (current.uid !== auth.userID) {
         throw new NotAllowedError('edit a subject comment which is not yours');
       }
+      // 对齐 Go：被禁言用户不允许编辑吐槽
+      if (auth.permission.ban_post) {
+        throw new NotAllowedError('edit a subject comment');
+      }
 
-      const normalizedComment = comment.normalize('NFC');
-      if (normalizedComment.length > 380) {
-        throw new BadRequestError('comment too long');
+      // 对齐 Go UpdateComment：NFC normalize → trim → 不可见字符检查 → 380 长度限制
+      const normalizedComment = comment.normalize('NFC').trim();
+      if (normalizedComment === '') {
+        throw new BadRequestError('comment is required');
+      }
+      if (!Dam.allCharacterPrintable(normalizedComment)) {
+        throw new BadRequestError('invisible character are included in comment');
+      }
+      if ([...normalizedComment].length > 380) {
+        throw new BadRequestError('comment too long, only allow less equal than 380 characters');
       }
 
       await rateLimit(LimitAction.Comment, auth.userID);
@@ -918,8 +956,12 @@ export async function setup(app: App) {
         updatedAt: DateTime.now().toUnixInteger(),
         updateIp: ip,
       };
-      if (dam.needReview(normalizedComment) || auth.permission.ban_post) {
+      if (dam.needReview(normalizedComment)) {
+        // 对齐 Go ShadowBan：触发敏感词 → 禁止公开
         toUpdate.privacy = CollectionPrivacy.Ban;
+      } else if (current.privacy === CollectionPrivacy.Ban) {
+        // 对齐 Go ShadowBan 解除：不再触发敏感词时恢复为仅自己可见
+        toUpdate.privacy = CollectionPrivacy.Private;
       }
       await db
         .update(schema.chiiSubjectInterests)

--- a/routes/private/routes/subject.ts
+++ b/routes/private/routes/subject.ts
@@ -11,7 +11,9 @@ import { Notify, NotifyType } from '@app/lib/notify.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
 import { getEpStatus } from '@app/lib/subject/ep';
 import type { SubjectFilter, SubjectSort } from '@app/lib/subject/type.ts';
-import { CollectionPrivacy } from '@app/lib/subject/type.ts';
+import { CollectionPrivacy, getCollectionTypeField } from '@app/lib/subject/type.ts';
+import { updateSubjectCollectionCounts, updateSubjectRating } from '@app/lib/subject/utils.ts';
+import { AsyncTimelineWriter } from '@app/lib/timeline/writer.ts';
 import { CanViewTopicContent, CanViewTopicReply } from '@app/lib/topic/display.ts';
 import { canEditTopic, canReplyPost } from '@app/lib/topic/state';
 import { CommentState, TopicDisplay } from '@app/lib/topic/type.ts';
@@ -722,6 +724,321 @@ export async function setup(app: App) {
         data: comments,
         total: count,
       };
+    },
+  );
+
+  app.post(
+    '/subjects/:subjectID/comments',
+    {
+      schema: {
+        summary: '发表条目的吐槽',
+        description: '吐槽挂在条目收藏上：已收藏则更新吐槽，未收藏需传 type 创建收藏并写吐槽',
+        operationId: 'createSubjectComment',
+        tags: [Tag.Subject],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          subjectID: t.Integer(),
+        }),
+        body: t.Intersect([req.Ref(req.CreateSubjectComment), req.Ref(req.TurnstileToken)]),
+        response: {
+          200: t.Object({
+            id: t.Integer({ description: 'new comment id' }),
+          }),
+          429: res.Ref(res.Error),
+        },
+      },
+      preHandler: [requireLogin('create subject comment'), requireTurnstileToken()],
+    },
+    async ({ auth, ip, body, params: { subjectID } }) => {
+      const subject = await fetcher.fetchSlimSubjectByID(subjectID, auth.allowNsfw);
+      if (!subject) {
+        throw new NotFoundError(`subject ${subjectID}`);
+      }
+
+      let comment = body.comment;
+      let rate = body.rate;
+      const type = body.type;
+
+      comment = comment.normalize('NFC');
+      if (comment.length > 380) {
+        throw new BadRequestError('comment too long');
+      }
+
+      await rateLimit(LimitAction.Subject, auth.userID);
+
+      let needTimeline = false;
+      let privacy: number = CollectionPrivacy.Public;
+      let commentID = 0;
+      const now = DateTime.now().toUnixInteger();
+      await db.transaction(async (t) => {
+        const [interest] = await t
+          .select()
+          .from(schema.chiiSubjectInterests)
+          .where(
+            op.and(
+              op.eq(schema.chiiSubjectInterests.uid, auth.userID),
+              op.eq(schema.chiiSubjectInterests.subjectID, subjectID),
+            ),
+          )
+          .limit(1);
+        if (rate === undefined) {
+          rate = 0;
+        }
+        if (interest) {
+          commentID = interest.id;
+          const oldRate = interest.rate;
+          const oldType = interest.type;
+          const toUpdate: Partial<orm.ISubjectInterest> = {
+            comment,
+            hasComment: 1,
+            updatedAt: now,
+            updateIp: ip,
+          };
+          if (type && oldType !== type) {
+            needTimeline = true;
+            toUpdate.type = type;
+            toUpdate[`${getCollectionTypeField(type)}Dateline`] = now;
+            await updateSubjectCollectionCounts(t, subjectID, type, oldType);
+          }
+          if (oldRate !== rate) {
+            toUpdate.rate = rate;
+          }
+          if (dam.needReview(comment) || auth.permission.ban_post) {
+            privacy = CollectionPrivacy.Ban;
+            toUpdate.privacy = CollectionPrivacy.Ban;
+          }
+          await t
+            .update(schema.chiiSubjectInterests)
+            .set(toUpdate)
+            .where(op.eq(schema.chiiSubjectInterests.id, interest.id))
+            .limit(1);
+          if (oldRate !== rate) {
+            await updateSubjectRating(t, subjectID, oldRate, rate);
+          }
+        } else {
+          if (!type) {
+            throw new BadRequestError('type is required on new subject comment');
+          }
+          if (dam.needReview(comment) || auth.permission.ban_post) {
+            privacy = CollectionPrivacy.Ban;
+          }
+          const field = getCollectionTypeField(type);
+          const toInsert: typeof schema.chiiSubjectInterests.$inferInsert = {
+            uid: auth.userID,
+            subjectID,
+            subjectType: subject.type,
+            rate,
+            type,
+            hasComment: 1,
+            comment,
+            tag: '',
+            epStatus: 0,
+            volStatus: 0,
+            wishDateline: 0,
+            doingDateline: 0,
+            collectDateline: 0,
+            onHoldDateline: 0,
+            droppedDateline: 0,
+            createIp: ip,
+            updateIp: ip,
+            updatedAt: now,
+            privacy,
+            [`${field}Dateline`]: now,
+          };
+          const [result] = await t.insert(schema.chiiSubjectInterests).values(toInsert);
+          commentID = result.insertId;
+          needTimeline = true;
+          await updateSubjectCollectionCounts(t, subjectID, type);
+          if (rate) {
+            await updateSubjectRating(t, subjectID, 0, rate);
+          }
+        }
+      });
+
+      if (needTimeline && privacy === CollectionPrivacy.Public) {
+        await AsyncTimelineWriter.subject({
+          uid: auth.userID,
+          subject: {
+            id: subject.id,
+            type: subject.type,
+          },
+          collect: {
+            id: commentID,
+            type: type ?? 0,
+            rate: rate ?? 0,
+            comment,
+          },
+          createdAt: now,
+          source: auth.source,
+        });
+      }
+      return { id: commentID };
+    },
+  );
+
+  app.put(
+    '/subjects/-/comments/:commentID',
+    {
+      schema: {
+        summary: '编辑条目的吐槽',
+        operationId: 'updateSubjectComment',
+        tags: [Tag.Subject],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          commentID: t.Integer({ minimum: 1 }),
+        }),
+        body: req.Ref(req.UpdateSubjectComment),
+        response: {
+          200: t.Object({}),
+        },
+      },
+      preHandler: [requireLogin('edit a subject comment')],
+    },
+    async ({ auth, ip, body: { comment }, params: { commentID } }) => {
+      const [current] = await db
+        .select()
+        .from(schema.chiiSubjectInterests)
+        .where(op.eq(schema.chiiSubjectInterests.id, commentID))
+        .limit(1);
+      if (!current || current.hasComment !== 1) {
+        throw new NotFoundError(`subject comment ${commentID}`);
+      }
+      if (current.uid !== auth.userID) {
+        throw new NotAllowedError('edit a subject comment which is not yours');
+      }
+
+      const normalizedComment = comment.normalize('NFC');
+      if (normalizedComment.length > 380) {
+        throw new BadRequestError('comment too long');
+      }
+
+      await rateLimit(LimitAction.Comment, auth.userID);
+      const toUpdate: Partial<orm.ISubjectInterest> = {
+        comment: normalizedComment,
+        updatedAt: DateTime.now().toUnixInteger(),
+        updateIp: ip,
+      };
+      if (dam.needReview(normalizedComment) || auth.permission.ban_post) {
+        toUpdate.privacy = CollectionPrivacy.Ban;
+      }
+      await db
+        .update(schema.chiiSubjectInterests)
+        .set(toUpdate)
+        .where(op.eq(schema.chiiSubjectInterests.id, commentID))
+        .limit(1);
+      return {};
+    },
+  );
+
+  app.delete(
+    '/subjects/-/comments/:commentID',
+    {
+      schema: {
+        summary: '删除条目的吐槽',
+        description: '删除吐槽会清空吐槽内容并保留收藏记录',
+        operationId: 'deleteSubjectComment',
+        tags: [Tag.Subject],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          commentID: t.Integer({ minimum: 1 }),
+        }),
+        response: {
+          200: t.Object({}),
+        },
+      },
+      preHandler: [requireLogin('delete a subject comment')],
+    },
+    async ({ auth, params: { commentID } }) => {
+      const [current] = await db
+        .select()
+        .from(schema.chiiSubjectInterests)
+        .where(op.eq(schema.chiiSubjectInterests.id, commentID))
+        .limit(1);
+      if (!current || current.hasComment !== 1) {
+        throw new NotFoundError(`subject comment ${commentID}`);
+      }
+      if (current.uid !== auth.userID) {
+        throw new NotAllowedError('delete a subject comment which is not yours');
+      }
+      await rateLimit(LimitAction.Comment, auth.userID);
+      await db
+        .update(schema.chiiSubjectInterests)
+        .set({
+          comment: '',
+          hasComment: 0,
+          updatedAt: DateTime.now().toUnixInteger(),
+        })
+        .where(op.eq(schema.chiiSubjectInterests.id, commentID))
+        .limit(1);
+      return {};
+    },
+  );
+
+  app.put(
+    '/subjects/-/comments/:commentID/like',
+    {
+      schema: {
+        summary: '给条目的吐槽点赞',
+        operationId: 'likeSubjectComment',
+        tags: [Tag.Subject],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          commentID: t.Integer(),
+        }),
+        body: t.Object({
+          value: t.Integer(),
+        }),
+        response: {
+          200: t.Object({}),
+          429: res.Ref(res.Error),
+        },
+      },
+      preHandler: [requireLogin('liking a subject comment')],
+    },
+    async ({ auth, params: { commentID }, body: { value } }) => {
+      const [comment] = await db
+        .select({ subjectID: schema.chiiSubjectInterests.subjectID })
+        .from(schema.chiiSubjectInterests)
+        .where(op.eq(schema.chiiSubjectInterests.id, commentID))
+        .limit(1);
+      if (!comment) {
+        throw new NotFoundError(`comment ${commentID}`);
+      }
+      await Reaction.add({
+        type: LikeType.SubjectCollect,
+        mid: comment.subjectID,
+        rid: commentID,
+        uid: auth.userID,
+        value,
+      });
+      return {};
+    },
+  );
+
+  app.delete(
+    '/subjects/-/comments/:commentID/like',
+    {
+      schema: {
+        summary: '取消条目的吐槽点赞',
+        operationId: 'unlikeSubjectComment',
+        tags: [Tag.Subject],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          commentID: t.Integer(),
+        }),
+        response: {
+          200: t.Object({}),
+        },
+      },
+      preHandler: [requireLogin('liking a subject comment')],
+    },
+    async ({ auth, params: { commentID } }) => {
+      await Reaction.delete({
+        type: LikeType.SubjectCollect,
+        rid: commentID,
+        uid: auth.userID,
+      });
+      return {};
     },
   );
 

--- a/routes/schemas.ts
+++ b/routes/schemas.ts
@@ -37,6 +37,7 @@ function addRequestSchemas(app: App) {
   app.addSchema(req.CreateIndexRelated);
   app.addSchema(req.CreateReply);
   app.addSchema(req.CreateReport);
+  app.addSchema(req.CreateSubjectComment);
   app.addSchema(req.CreateTopic);
   app.addSchema(req.FilterMode);
   app.addSchema(req.GroupFilterMode);
@@ -57,6 +58,7 @@ function addRequestSchemas(app: App) {
   app.addSchema(req.UpdateEpisodeProgress);
   app.addSchema(req.UpdateIndex);
   app.addSchema(req.UpdateIndexRelated);
+  app.addSchema(req.UpdateSubjectComment);
   app.addSchema(req.UpdateSubjectProgress);
   app.addSchema(req.UpdateTopic);
 }


### PR DESCRIPTION
## 目的

条目吐槽箱此前只有读取接口（`GET /subjects/:subjectID/comments`），用户无法发表/编辑/删除条目吐槽。本次补齐写接口，与现有读取结构完全配套，行为对齐旧站 `SubjectInterestUpdate`。

## 设计

吐槽物理上挂在条目收藏记录（`chii_subject_interests`）上，与 GET 返回的 `SubjectInterestComment`（`id/user/type/rate/comment/reactions/updatedAt`）配套：

- 发表吐槽 = 写收藏记录的 `comment` 字段（`hasComment=1`）：已收藏则更新吐槽；未收藏需传 `type` 创建收藏记录（并更新条目收藏计数、写时间线）
- 吐槽可带状态标签 `type`（看过/在看/想看等）与评分 `rate`（对齐旧站，非纯文本）
- 敏感词/禁言 → 隐私 BAN（GET 不再可见），对齐 `updateSubjectCollection` 的既有行为
- 点赞用 `LikeType.SubjectCollect`，与 GET 的 `reactions` 同源

## 端点（routes/private/routes/subject.ts）

1. `POST /subjects/:subjectID/comments`（createSubjectComment，登录 + turnstile）
   body: `{ comment, type?, rate? }`，返回 `{ id }`
2. `PUT /subjects/-/comments/:commentID`（updateSubjectComment，仅本人）
   body: `{ comment }`
3. `DELETE /subjects/-/comments/:commentID`（deleteSubjectComment，仅本人）
   清空吐槽并保留收藏记录
4. `PUT /subjects/-/comments/:commentID/like`（likeSubjectComment）
   body: `{ value }`
5. `DELETE /subjects/-/comments/:commentID/like`（unlikeSubjectComment）

## 测试

`subject.test.ts` 新增 11 个用例：已有收藏更新吐槽、新收藏创建+计数、type 必填、未登录 401、本人编辑/删除、他人 403、点赞/取消点赞。相关套件 98 tests 全过，`tsc`/`eslint` 无错误。

## 其他

- `lib/types/req.ts`：新增 `CreateSubjectComment`/`UpdateSubjectComment` schema
- `routes/schemas.ts`：注册新 schema
- `openapi.json`：重新生成（新增 5 个 operation）