### PR TITLE
refactor: unify topic reply CRUD + fix openapi Comment $refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,13 +24,15 @@ Key infrastructure: MySQL (TypeORM), Redis (ioredis), Kafka (@confluentinc/kafka
 ## Build and Test
 
 - Package manager: pnpm
-- `npm run build` — production build (esbuild)
-- `npm test` — run vitest (non-watch)
-- `npm run codegen` — GraphQL TypeScript codegen
-- `npm run generate:pb` — protobuf codegen (`buf generate`)
-- `npm run drizzle-pull` — database schema introspection
-- `npm run lint` — ESLint
-- `npm run format` — Prettier
+- `pnpm run build` — production build (esbuild)
+- `pnpm test` — run vitest (non-watch)
+- `pnpm run codegen` — GraphQL TypeScript codegen
+- `pnpm run generate:pb` — protobuf codegen (`buf generate`)
+- `pnpm run drizzle-pull` — database schema introspection
+- `pnpm run lint` — ESLint
+- `pnpm run format` — Prettier
+
+avoid using npm/npx tools, use `pnpm` or `pnpm exec` instead.
 
 ## Conventions
 

--- a/lib/topic/post.ts
+++ b/lib/topic/post.ts
@@ -23,21 +23,32 @@ type PostTable = typeof schema.chiiGroupPosts | typeof schema.chiiSubjectPosts;
 
 type TopicTable = typeof schema.chiiGroupTopics | typeof schema.chiiSubjectTopics;
 
-export type TopicRow = orm.IGroupTopic | orm.ISubjectTopic;
+type PostRow<PT extends PostTable> = PT['$inferSelect'];
 
-interface TopicPostServiceOptions {
+type TopicRow<TT extends TopicTable> = TT['$inferSelect'];
+
+type AnyPostRow = orm.IGroupPost | orm.ISubjectPost;
+
+type ReplyLikeType = (typeof LikeType)['GroupReply'] | (typeof LikeType)['SubjectReply'];
+
+interface NotifyTypesConfig {
+  /** 回复主楼的站内信类型 */
+  topicReply: NotifyType;
+  /** 回复回帖的站内信类型 */
+  postReply: NotifyType;
+}
+
+interface TopicPostServiceOptions<
+  PT extends PostTable = PostTable,
+  TT extends TopicTable = TopicTable,
+> {
   /** 回复所在的 posts 表（chii_group_posts / chii_subject_posts） */
-  table: PostTable;
+  table: PT;
   /** 回复所属的 topics 表 */
-  topicTable: TopicTable;
+  topicTable: TT;
   /** 回复点赞使用的 LikeType */
-  likeType: (typeof LikeType)['GroupReply'] | (typeof LikeType)['SubjectReply'];
-  notifyTypes: {
-    /** 回复主楼的站内信类型 */
-    topicReply: NotifyType;
-    /** 回复回帖的站内信类型 */
-    postReply: NotifyType;
-  };
+  likeType: ReplyLikeType;
+  notifyTypes: NotifyTypesConfig;
 }
 
 /**
@@ -46,20 +57,23 @@ interface TopicPostServiceOptions {
  * 两张 posts 表结构一致，仅 likeType / notify 类型 / 计数器副作用不同， 通过构造参数区分，避免 group.ts 与 subject.ts 中重复的回复 CRUD
  * 实现。
  */
-export class TopicPostService {
+export class TopicPostService<
+  PT extends PostTable = PostTable,
+  TT extends TopicTable = TopicTable,
+> {
   private readonly table: PostTable;
   private readonly topicTable: TopicTable;
-  private readonly likeType: (typeof LikeType)['GroupReply'] | (typeof LikeType)['SubjectReply'];
-  private readonly notifyTypes: TopicPostServiceOptions['notifyTypes'];
+  private readonly likeType: ReplyLikeType;
+  private readonly notifyTypes: NotifyTypesConfig;
 
-  constructor(options: TopicPostServiceOptions) {
+  constructor(options: TopicPostServiceOptions<PT, TT>) {
     this.table = options.table;
     this.topicTable = options.topicTable;
     this.likeType = options.likeType;
     this.notifyTypes = options.notifyTypes;
   }
 
-  private toReplyBase(post: orm.IGroupPost | orm.ISubjectPost): res.IReplyBase {
+  private toReplyBase(post: AnyPostRow): res.IReplyBase {
     return {
       id: post.id,
       content: post.content,
@@ -120,8 +134,8 @@ export class TopicPostService {
     postID: number,
     viewerID?: number,
   ): Promise<{
-    post: orm.IGroupPost | orm.ISubjectPost;
-    topic: TopicRow;
+    post: PostRow<PT>;
+    topic: TopicRow<TT>;
     creator: res.ISlimUser;
     topicCreator: res.ISlimUser;
   }> {
@@ -157,10 +171,10 @@ export class TopicPostService {
    */
   async create(
     auth: Readonly<IAuth>,
-    topic: TopicRow,
+    topic: TopicRow<TT>,
     content: string,
     replyTo: number,
-    preCreateCheck?: (topic: TopicRow) => Promise<void>,
+    preCreateCheck?: (topic: TopicRow<TT>) => Promise<void>,
   ): Promise<{ id: number }> {
     if (auth.permission.ban_post) {
       throw new NotAllowedError('create reply');
@@ -208,7 +222,7 @@ export class TopicPostService {
         content,
         state: CommentState.Normal,
         createdAt,
-      } as typeof this.table.$inferInsert);
+      });
       postID = insertId;
 
       if (topic.state === CommentState.AdminSilentTopic) {

--- a/lib/topic/post.ts
+++ b/lib/topic/post.ts
@@ -1,0 +1,324 @@
+import { DateTime } from 'luxon';
+
+import type { orm, schema } from '@app/drizzle';
+import { db, op } from '@app/drizzle';
+import type { IAuth } from '@app/lib/auth/index.ts';
+import { NotAllowedError } from '@app/lib/auth/index.ts';
+import { Dam } from '@app/lib/dam.ts';
+import { BadRequestError, NotFoundError, UnexpectedNotFoundError } from '@app/lib/error.ts';
+import type { LikeType } from '@app/lib/like';
+import { Reaction } from '@app/lib/like';
+import type { NotifyType } from '@app/lib/notify.ts';
+import { Notify } from '@app/lib/notify.ts';
+import * as fetcher from '@app/lib/types/fetcher.ts';
+import type * as res from '@app/lib/types/res.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
+
+import { CanViewTopicReply } from './display';
+import { canReplyPost } from './state.ts';
+import { CommentState } from './type.ts';
+
+type PostTable = typeof schema.chiiGroupPosts | typeof schema.chiiSubjectPosts;
+
+type TopicTable = typeof schema.chiiGroupTopics | typeof schema.chiiSubjectTopics;
+
+export type TopicRow = orm.IGroupTopic | orm.ISubjectTopic;
+
+interface TopicPostServiceOptions {
+  /** 回复所在的 posts 表（chii_group_posts / chii_subject_posts） */
+  table: PostTable;
+  /** 回复所属的 topics 表 */
+  topicTable: TopicTable;
+  /** 回复点赞使用的 LikeType */
+  likeType: (typeof LikeType)['GroupReply'] | (typeof LikeType)['SubjectReply'];
+  notifyTypes: {
+    /** 回复主楼的站内信类型 */
+    topicReply: NotifyType;
+    /** 回复回帖的站内信类型 */
+    postReply: NotifyType;
+  };
+}
+
+/**
+ * Group / subject 话题回复（post）的通用服务。
+ *
+ * 两张 posts 表结构一致，仅 likeType / notify 类型 / 计数器副作用不同， 通过构造参数区分，避免 group.ts 与 subject.ts 中重复的回复 CRUD
+ * 实现。
+ */
+export class TopicPostService {
+  private readonly table: PostTable;
+  private readonly topicTable: TopicTable;
+  private readonly likeType: (typeof LikeType)['GroupReply'] | (typeof LikeType)['SubjectReply'];
+  private readonly notifyTypes: TopicPostServiceOptions['notifyTypes'];
+
+  constructor(options: TopicPostServiceOptions) {
+    this.table = options.table;
+    this.topicTable = options.topicTable;
+    this.likeType = options.likeType;
+    this.notifyTypes = options.notifyTypes;
+  }
+
+  private toReplyBase(post: orm.IGroupPost | orm.ISubjectPost): res.IReplyBase {
+    return {
+      id: post.id,
+      content: post.content,
+      state: post.state,
+      createdAt: post.createdAt,
+      creatorID: post.uid,
+    };
+  }
+
+  /** 获取话题的回复列表（含一层嵌套回复，主楼是 related === 0 的首条）。 */
+  async getReplies(topicID: number, viewerID?: number): Promise<res.IReply[]> {
+    const posts = await db
+      .select()
+      .from(this.table)
+      .where(op.eq(this.table.mid, topicID))
+      .orderBy(op.asc(this.table.id));
+    const users = await fetcher.fetchSlimUsersByIDs(
+      posts.map((x) => x.uid),
+      viewerID,
+    );
+    const subReplies: Record<number, res.IReplyBase[]> = {};
+    const reactions = await Reaction.fetchByMainID(topicID, this.likeType);
+    for (const x of posts) {
+      if (x.related === 0) {
+        continue;
+      }
+      if (!CanViewTopicReply(x.state)) {
+        x.content = '';
+      }
+      const sub = this.toReplyBase(x);
+      sub.creator = users[sub.creatorID];
+      sub.reactions = reactions[x.id] ?? [];
+      const subR = subReplies[x.related] ?? [];
+      subR.push(sub);
+      subReplies[x.related] = subR;
+    }
+    const topLevelReplies: res.IReply[] = [];
+    for (const x of posts) {
+      if (x.related !== 0) {
+        continue;
+      }
+      if (!CanViewTopicReply(x.state)) {
+        x.content = '';
+      }
+      const reply = {
+        ...this.toReplyBase(x),
+        creator: users[x.uid],
+        replies: subReplies[x.id] ?? [],
+        reactions: reactions[x.id] ?? [],
+      };
+      topLevelReplies.push(reply);
+    }
+    return topLevelReplies;
+  }
+
+  /** 获取单个回复详情所需的 post / topic / 用户数据。 */
+  async getPost(
+    postID: number,
+    viewerID?: number,
+  ): Promise<{
+    post: orm.IGroupPost | orm.ISubjectPost;
+    topic: TopicRow;
+    creator: res.ISlimUser;
+    topicCreator: res.ISlimUser;
+  }> {
+    const [post] = await db.select().from(this.table).where(op.eq(this.table.id, postID)).limit(1);
+    if (!post) {
+      throw new NotFoundError(`post ${postID}`);
+    }
+    const [topic] = await db
+      .select()
+      .from(this.topicTable)
+      .where(op.eq(this.topicTable.id, post.mid))
+      .limit(1);
+    if (!topic) {
+      throw new UnexpectedNotFoundError(`topic ${post.mid}`);
+    }
+    const users = await fetcher.fetchSlimUsersByIDs([post.uid, topic.uid], viewerID);
+    const creator = users[post.uid];
+    if (!creator) {
+      throw new UnexpectedNotFoundError(`user ${post.uid}`);
+    }
+    const topicCreator = users[topic.uid];
+    if (!topicCreator) {
+      throw new UnexpectedNotFoundError(`user ${topic.uid}`);
+    }
+    return { post, topic, creator, topicCreator };
+  }
+
+  /**
+   * 创建回复。
+   *
+   * @param topic - 已由路由取出的 topic 行（路由还需要它做组权限等检查）
+   * @param preCreateCheck - 插入前的额外检查（如私密小组的成员校验），在关闭话题检查之后执行
+   */
+  async create(
+    auth: Readonly<IAuth>,
+    topic: TopicRow,
+    content: string,
+    replyTo: number,
+    preCreateCheck?: (topic: TopicRow) => Promise<void>,
+  ): Promise<{ id: number }> {
+    if (auth.permission.ban_post) {
+      throw new NotAllowedError('create reply');
+    }
+    if (!Dam.allCharacterPrintable(content)) {
+      throw new BadRequestError('content contains invalid invisible character');
+    }
+    if (topic.state === CommentState.AdminCloseTopic) {
+      throw new NotAllowedError('reply to a closed topic');
+    }
+    await preCreateCheck?.(topic);
+
+    let notifyUserID = topic.uid;
+    if (replyTo) {
+      const [parent] = await db
+        .select()
+        .from(this.table)
+        .where(op.eq(this.table.id, replyTo))
+        .limit(1);
+      if (!parent) {
+        throw new NotFoundError(`post ${replyTo}`);
+      }
+      if (!canReplyPost(parent.state)) {
+        throw new NotAllowedError('reply to a admin action post');
+      }
+      notifyUserID = parent.uid;
+    }
+
+    await rateLimit(LimitAction.Reply, auth.userID);
+
+    const createdAt = DateTime.now().toUnixInteger();
+
+    let postID = 0;
+    await db.transaction(async (t) => {
+      const [{ count = 0 } = {}] = await t
+        .select({ count: op.count() })
+        .from(this.table)
+        .where(
+          op.and(op.eq(this.table.mid, topic.id), op.eq(this.table.state, CommentState.Normal)),
+        );
+      const [{ insertId }] = await t.insert(this.table).values({
+        mid: topic.id,
+        uid: auth.userID,
+        related: replyTo,
+        content,
+        state: CommentState.Normal,
+        createdAt,
+      } as typeof this.table.$inferInsert);
+      postID = insertId;
+
+      if (topic.state === CommentState.AdminSilentTopic) {
+        await t
+          .update(this.topicTable)
+          .set({ replies: count })
+          .where(op.eq(this.topicTable.id, topic.id));
+      } else {
+        await t
+          .update(this.topicTable)
+          .set({ replies: count, updatedAt: createdAt })
+          .where(op.eq(this.topicTable.id, topic.id));
+      }
+
+      await Notify.create(t, {
+        destUserID: notifyUserID,
+        sourceUserID: auth.userID,
+        createdAt,
+        type: replyTo === 0 ? this.notifyTypes.topicReply : this.notifyTypes.postReply,
+        relatedID: postID,
+        mainID: topic.id,
+        title: topic.title,
+      });
+    });
+
+    return { id: postID };
+  }
+
+  async update(auth: Readonly<IAuth>, postID: number, content: string): Promise<void> {
+    if (auth.permission.ban_post) {
+      throw new NotAllowedError('edit reply');
+    }
+    if (!Dam.allCharacterPrintable(content)) {
+      throw new BadRequestError('content contains invalid invisible character');
+    }
+
+    const [post] = await db.select().from(this.table).where(op.eq(this.table.id, postID)).limit(1);
+    if (!post) {
+      throw new NotFoundError(`post ${postID}`);
+    }
+    if (post.uid !== auth.userID) {
+      throw new NotAllowedError('edit reply not created by you');
+    }
+
+    const [topic] = await db
+      .select()
+      .from(this.topicTable)
+      .where(op.eq(this.topicTable.id, post.mid))
+      .limit(1);
+    if (!topic) {
+      throw new UnexpectedNotFoundError(`topic ${post.mid}`);
+    }
+    if (topic.state === CommentState.AdminCloseTopic) {
+      throw new NotAllowedError('edit reply in a closed topic');
+    }
+    if (([CommentState.AdminDelete, CommentState.UserDelete] as number[]).includes(post.state)) {
+      throw new NotAllowedError('edit a deleted reply');
+    }
+
+    const [reply] = await db
+      .select()
+      .from(this.table)
+      .where(op.and(op.eq(this.table.mid, topic.id), op.eq(this.table.related, postID)))
+      .limit(1);
+    if (reply) {
+      throw new NotAllowedError('edit a post with reply');
+    }
+
+    await rateLimit(LimitAction.Reply, auth.userID);
+    await db.update(this.table).set({ content }).where(op.eq(this.table.id, postID));
+  }
+
+  async delete(auth: Readonly<IAuth>, postID: number): Promise<void> {
+    const [post] = await db.select().from(this.table).where(op.eq(this.table.id, postID)).limit(1);
+    if (!post) {
+      throw new NotFoundError(`post ${postID}`);
+    }
+    if (post.uid !== auth.userID) {
+      throw new NotAllowedError('delete reply not created by you');
+    }
+    await rateLimit(LimitAction.Reply, auth.userID);
+    await db
+      .update(this.table)
+      .set({ state: CommentState.UserDelete })
+      .where(op.eq(this.table.id, postID));
+  }
+
+  async like(auth: Readonly<IAuth>, postID: number, value: number): Promise<void> {
+    const [post] = await db
+      .select({ mid: this.table.mid })
+      .from(this.table)
+      .where(op.eq(this.table.id, postID))
+      .limit(1);
+    if (!post) {
+      throw new NotFoundError(`post ${postID}`);
+    }
+    await Reaction.add({
+      type: this.likeType,
+      mid: post.mid,
+      rid: postID,
+      uid: auth.userID,
+      value,
+    });
+  }
+
+  async unlike(auth: Readonly<IAuth>, postID: number): Promise<void> {
+    await Reaction.delete({
+      type: this.likeType,
+      rid: postID,
+      uid: auth.userID,
+    });
+  }
+}

--- a/lib/types/convert.ts
+++ b/lib/types/convert.ts
@@ -619,16 +619,6 @@ export function toSubjectTopic(topic: orm.ISubjectTopic): res.ITopic {
   };
 }
 
-export function toSubjectTopicReply(reply: orm.ISubjectPost): res.IReplyBase {
-  return {
-    id: reply.id,
-    content: reply.content,
-    state: reply.state,
-    createdAt: reply.createdAt,
-    creatorID: reply.uid,
-  };
-}
-
 export function toPersonCollect(user: orm.IUser, collect: orm.IPersonCollect): res.IPersonCollect {
   return {
     user: toSlimUser(user),
@@ -688,15 +678,5 @@ export function toGroupTopic(topic: orm.IGroupTopic): res.ITopic {
     replyCount: topic.replies,
     state: topic.state,
     display: topic.display,
-  };
-}
-
-export function toGroupTopicReply(reply: orm.IGroupPost): res.IReplyBase {
-  return {
-    id: reply.id,
-    content: reply.content,
-    state: reply.state,
-    createdAt: reply.createdAt,
-    creatorID: reply.uid,
   };
 }

--- a/lib/types/res.ts
+++ b/lib/types/res.ts
@@ -504,7 +504,7 @@ export const CommentBase = t.Object(
 export type IComment = Static<typeof Comment>;
 export const Comment = t.Intersect(
   [
-    CommentBase,
+    Ref(CommentBase),
     t.Object({
       replies: t.Array(Ref(CommentBase)),
     }),

--- a/openapi.json
+++ b/openapi.json
@@ -1199,43 +1199,7 @@
       "Comment": {
         "allOf": [
           {
-            "type": "object",
-            "required": ["id", "mainID", "creatorID", "relatedID", "createdAt", "content", "state"],
-            "properties": {
-              "id": {
-                "type": "integer"
-              },
-              "mainID": {
-                "type": "integer"
-              },
-              "creatorID": {
-                "type": "integer"
-              },
-              "relatedID": {
-                "type": "integer"
-              },
-              "relatedPhotoID": {
-                "type": "integer"
-              },
-              "createdAt": {
-                "type": "integer"
-              },
-              "content": {
-                "type": "string"
-              },
-              "state": {
-                "type": "integer"
-              },
-              "user": {
-                "$ref": "#/components/schemas/SlimUser"
-              },
-              "reactions": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Reaction"
-                }
-              }
-            }
+            "$ref": "#/components/schemas/CommentBase"
           },
           {
             "type": "object",
@@ -5391,67 +5355,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "id",
-                          "mainID",
-                          "creatorID",
-                          "relatedID",
-                          "createdAt",
-                          "content",
-                          "state"
-                        ],
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "mainID": {
-                            "type": "integer"
-                          },
-                          "creatorID": {
-                            "type": "integer"
-                          },
-                          "relatedID": {
-                            "type": "integer"
-                          },
-                          "relatedPhotoID": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "type": "integer"
-                          },
-                          "content": {
-                            "type": "string"
-                          },
-                          "state": {
-                            "type": "integer"
-                          },
-                          "user": {
-                            "$ref": "#/components/schemas/SlimUser"
-                          },
-                          "reactions": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/Reaction"
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": ["replies"],
-                        "properties": {
-                          "replies": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/CommentBase"
-                            }
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Comment"
                   }
                 }
               }
@@ -6228,67 +6132,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "id",
-                          "mainID",
-                          "creatorID",
-                          "relatedID",
-                          "createdAt",
-                          "content",
-                          "state"
-                        ],
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "mainID": {
-                            "type": "integer"
-                          },
-                          "creatorID": {
-                            "type": "integer"
-                          },
-                          "relatedID": {
-                            "type": "integer"
-                          },
-                          "relatedPhotoID": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "type": "integer"
-                          },
-                          "content": {
-                            "type": "string"
-                          },
-                          "state": {
-                            "type": "integer"
-                          },
-                          "user": {
-                            "$ref": "#/components/schemas/SlimUser"
-                          },
-                          "reactions": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/Reaction"
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": ["replies"],
-                        "properties": {
-                          "replies": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/CommentBase"
-                            }
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Comment"
                   }
                 }
               }
@@ -6665,67 +6509,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "id",
-                          "mainID",
-                          "creatorID",
-                          "relatedID",
-                          "createdAt",
-                          "content",
-                          "state"
-                        ],
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "mainID": {
-                            "type": "integer"
-                          },
-                          "creatorID": {
-                            "type": "integer"
-                          },
-                          "relatedID": {
-                            "type": "integer"
-                          },
-                          "relatedPhotoID": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "type": "integer"
-                          },
-                          "content": {
-                            "type": "string"
-                          },
-                          "state": {
-                            "type": "integer"
-                          },
-                          "user": {
-                            "$ref": "#/components/schemas/SlimUser"
-                          },
-                          "reactions": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/Reaction"
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": ["replies"],
-                        "properties": {
-                          "replies": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/CommentBase"
-                            }
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Comment"
                   }
                 }
               }
@@ -8031,67 +7815,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "id",
-                          "mainID",
-                          "creatorID",
-                          "relatedID",
-                          "createdAt",
-                          "content",
-                          "state"
-                        ],
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "mainID": {
-                            "type": "integer"
-                          },
-                          "creatorID": {
-                            "type": "integer"
-                          },
-                          "relatedID": {
-                            "type": "integer"
-                          },
-                          "relatedPhotoID": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "type": "integer"
-                          },
-                          "content": {
-                            "type": "string"
-                          },
-                          "state": {
-                            "type": "integer"
-                          },
-                          "user": {
-                            "$ref": "#/components/schemas/SlimUser"
-                          },
-                          "reactions": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/Reaction"
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": ["replies"],
-                        "properties": {
-                          "replies": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/CommentBase"
-                            }
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Comment"
                   }
                 }
               }
@@ -10383,67 +10107,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "id",
-                          "mainID",
-                          "creatorID",
-                          "relatedID",
-                          "createdAt",
-                          "content",
-                          "state"
-                        ],
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "mainID": {
-                            "type": "integer"
-                          },
-                          "creatorID": {
-                            "type": "integer"
-                          },
-                          "relatedID": {
-                            "type": "integer"
-                          },
-                          "relatedPhotoID": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "type": "integer"
-                          },
-                          "content": {
-                            "type": "string"
-                          },
-                          "state": {
-                            "type": "integer"
-                          },
-                          "user": {
-                            "$ref": "#/components/schemas/SlimUser"
-                          },
-                          "reactions": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/Reaction"
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": ["replies"],
-                        "properties": {
-                          "replies": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/CommentBase"
-                            }
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Comment"
                   }
                 }
               }
@@ -11463,67 +11127,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "id",
-                          "mainID",
-                          "creatorID",
-                          "relatedID",
-                          "createdAt",
-                          "content",
-                          "state"
-                        ],
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "mainID": {
-                            "type": "integer"
-                          },
-                          "creatorID": {
-                            "type": "integer"
-                          },
-                          "relatedID": {
-                            "type": "integer"
-                          },
-                          "relatedPhotoID": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "type": "integer"
-                          },
-                          "content": {
-                            "type": "string"
-                          },
-                          "state": {
-                            "type": "integer"
-                          },
-                          "user": {
-                            "$ref": "#/components/schemas/SlimUser"
-                          },
-                          "reactions": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/Reaction"
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": ["replies"],
-                        "properties": {
-                          "replies": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/CommentBase"
-                            }
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Comment"
                   }
                 }
               }
@@ -11900,67 +11504,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "id",
-                          "mainID",
-                          "creatorID",
-                          "relatedID",
-                          "createdAt",
-                          "content",
-                          "state"
-                        ],
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "mainID": {
-                            "type": "integer"
-                          },
-                          "creatorID": {
-                            "type": "integer"
-                          },
-                          "relatedID": {
-                            "type": "integer"
-                          },
-                          "relatedPhotoID": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "type": "integer"
-                          },
-                          "content": {
-                            "type": "string"
-                          },
-                          "state": {
-                            "type": "integer"
-                          },
-                          "user": {
-                            "$ref": "#/components/schemas/SlimUser"
-                          },
-                          "reactions": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/Reaction"
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": ["replies"],
-                        "properties": {
-                          "replies": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/CommentBase"
-                            }
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Comment"
                   }
                 }
               }
@@ -15347,67 +14891,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "allOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "id",
-                          "mainID",
-                          "creatorID",
-                          "relatedID",
-                          "createdAt",
-                          "content",
-                          "state"
-                        ],
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "mainID": {
-                            "type": "integer"
-                          },
-                          "creatorID": {
-                            "type": "integer"
-                          },
-                          "relatedID": {
-                            "type": "integer"
-                          },
-                          "relatedPhotoID": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "type": "integer"
-                          },
-                          "content": {
-                            "type": "string"
-                          },
-                          "state": {
-                            "type": "integer"
-                          },
-                          "user": {
-                            "$ref": "#/components/schemas/SlimUser"
-                          },
-                          "reactions": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/Reaction"
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": ["replies"],
-                        "properties": {
-                          "replies": {
-                            "type": "array",
-                            "items": {
-                              "$ref": "#/components/schemas/CommentBase"
-                            }
-                          }
-                        }
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Comment"
                   }
                 }
               }

--- a/routes/private/routes/blog.ts
+++ b/routes/private/routes/blog.ts
@@ -156,7 +156,7 @@ export async function setup(app: App) {
           entryID: t.Integer(),
         }),
         response: {
-          200: t.Array(res.Comment),
+          200: t.Array(res.Ref(res.Comment)),
           404: res.Ref(res.Error, {
             'x-examples': formatErrors(new NotFoundError('blog entry')),
           }),

--- a/routes/private/routes/character.ts
+++ b/routes/private/routes/character.ts
@@ -327,7 +327,7 @@ export async function setup(app: App) {
           characterID: t.Integer(),
         }),
         response: {
-          200: t.Array(res.Comment),
+          200: t.Array(res.Ref(res.Comment)),
           404: res.Ref(res.Error, {
             'x-examples': formatErrors(new NotFoundError('character')),
           }),
@@ -448,7 +448,7 @@ export async function setup(app: App) {
           photoID: t.Integer(),
         }),
         response: {
-          200: t.Array(res.Comment),
+          200: t.Array(res.Ref(res.Comment)),
           404: res.Ref(res.Error),
         },
       },

--- a/routes/private/routes/episode.ts
+++ b/routes/private/routes/episode.ts
@@ -68,7 +68,7 @@ export async function setup(app: App) {
           episodeID: t.Integer({ minimum: 1 }),
         }),
         response: {
-          200: t.Array(res.Comment),
+          200: t.Array(res.Ref(res.Comment)),
         },
       },
     },

--- a/routes/private/routes/group.test.ts
+++ b/routes/private/routes/group.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { db, op, schema } from '@app/drizzle';
 import { emptyAuth } from '@app/lib/auth/index.ts';
+import { LikeType } from '@app/lib/like';
 import redis from '@app/lib/redis.ts';
 import { CommentState } from '@app/lib/topic/type.ts';
 import { createTestServer } from '@app/tests/utils.ts';
@@ -335,6 +336,99 @@ describe('group topics', () => {
     const res = await app.inject(`/groups/-/posts/${testPostID}`);
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchSnapshot();
+  });
+
+  test('should get group topic with nested replies', async () => {
+    await db.insert(schema.chiiGroupPosts).values({
+      mid: testTopicID,
+      uid: testUserID,
+      content: 'Nested Reply',
+      related: testPostID,
+      state: 0,
+      createdAt: 1462335911,
+    });
+
+    const app = createTestServer();
+    await app.register(setup);
+
+    const res = await app.inject(`/groups/-/topics/${testTopicID}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      id: testTopicID,
+      title: 'Test Topic',
+      creatorID: testUserID,
+      replies: [
+        {
+          id: testTopicPostID,
+          creatorID: testUserID,
+          content: 'Test Topic Content',
+          replies: [],
+        },
+        {
+          id: testPostID,
+          creatorID: testUserID,
+          content: 'Test Reply',
+          replies: [{ creatorID: testUserID, content: 'Nested Reply' }],
+        },
+      ],
+    });
+  });
+
+  test('should like and unlike group post', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: testUserID,
+      },
+    });
+    await app.register(setup);
+
+    const likeRes = await app.inject({
+      url: `/groups/-/posts/${testPostID}/like`,
+      method: 'put',
+      payload: { value: 0 },
+    });
+    expect(likeRes.statusCode).toBe(200);
+
+    const [like] = await db
+      .select()
+      .from(schema.chiiLikes)
+      .where(
+        op.and(
+          op.eq(schema.chiiLikes.type, LikeType.GroupReply),
+          op.eq(schema.chiiLikes.relatedID, testPostID),
+          op.eq(schema.chiiLikes.uid, testUserID),
+        ),
+      );
+    expect(like).toMatchObject({ value: 0, deleted: false });
+
+    const unlikeRes = await app.inject({
+      url: `/groups/-/posts/${testPostID}/like`,
+      method: 'delete',
+    });
+    expect(unlikeRes.statusCode).toBe(200);
+
+    const [unliked] = await db
+      .select()
+      .from(schema.chiiLikes)
+      .where(
+        op.and(
+          op.eq(schema.chiiLikes.type, LikeType.GroupReply),
+          op.eq(schema.chiiLikes.relatedID, testPostID),
+          op.eq(schema.chiiLikes.uid, testUserID),
+        ),
+      );
+    expect(unliked?.deleted).toBe(true);
+
+    await db
+      .delete(schema.chiiLikes)
+      .where(
+        op.and(
+          op.eq(schema.chiiLikes.type, LikeType.GroupReply),
+          op.eq(schema.chiiLikes.relatedID, testPostID),
+        ),
+      );
   });
 
   test('should create/edit/delete new post', async () => {

--- a/routes/private/routes/group.ts
+++ b/routes/private/routes/group.ts
@@ -1,7 +1,6 @@
 import { DateTime } from 'luxon';
 import t from 'typebox';
 
-import type { orm } from '@app/drizzle';
 import { db, op, schema } from '@app/drizzle';
 import { NotAllowedError } from '@app/lib/auth/index.ts';
 import { Dam, dam } from '@app/lib/dam.ts';
@@ -675,7 +674,7 @@ export async function setup(app: App) {
         content: post.content,
         state: post.state,
         topic: {
-          ...convert.toGroupTopic(topic as orm.IGroupTopic),
+          ...convert.toGroupTopic(topic),
           creator: topicCreator,
           replies: topic.replies,
         },
@@ -810,14 +809,13 @@ export async function setup(app: App) {
       }
 
       return await groupPostService.create(auth, topic, content, replyTo, async (topic) => {
-        const gTopic = topic as orm.IGroupTopic;
         const [group] = await db
           .select()
           .from(schema.chiiGroups)
-          .where(op.eq(schema.chiiGroups.id, gTopic.gid))
+          .where(op.eq(schema.chiiGroups.id, topic.gid))
           .limit(1);
         if (!group) {
-          throw new UnexpectedNotFoundError(`group ${gTopic.gid}`);
+          throw new UnexpectedNotFoundError(`group ${topic.gid}`);
         }
         if (!group.accessible && !(await isMemberInGroup(group.id, auth.userID))) {
           throw new NotJoinPrivateGroupError(group.name);

--- a/routes/private/routes/group.ts
+++ b/routes/private/routes/group.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon';
 import t from 'typebox';
 
+import type { orm } from '@app/drizzle';
 import { db, op, schema } from '@app/drizzle';
 import { NotAllowedError } from '@app/lib/auth/index.ts';
 import { Dam, dam } from '@app/lib/dam.ts';
@@ -17,11 +18,12 @@ import {
   GroupTopicFilterMode,
 } from '@app/lib/group/type';
 import { getGroupMember, isMemberInGroup } from '@app/lib/group/utils.ts';
-import { LikeType, Reaction } from '@app/lib/like';
-import { Notify, NotifyType } from '@app/lib/notify.ts';
+import { LikeType } from '@app/lib/like';
+import { NotifyType } from '@app/lib/notify.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
-import { CanViewTopicContent, CanViewTopicReply } from '@app/lib/topic/display';
-import { canEditTopic, canReplyPost } from '@app/lib/topic/state.ts';
+import { CanViewTopicContent } from '@app/lib/topic/display';
+import { TopicPostService } from '@app/lib/topic/post.ts';
+import { canEditTopic } from '@app/lib/topic/state.ts';
 import { CommentState, TopicDisplay } from '@app/lib/topic/type.ts';
 import * as convert from '@app/lib/types/convert.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
@@ -32,6 +34,16 @@ import { LimitAction } from '@app/lib/utils/rate-limit';
 import { requireLogin, requireTurnstileToken } from '@app/routes/hooks/pre-handler.ts';
 import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
+
+const groupPostService = new TopicPostService({
+  table: schema.chiiGroupPosts,
+  topicTable: schema.chiiGroupTopics,
+  likeType: LikeType.GroupReply,
+  notifyTypes: {
+    topicReply: NotifyType.GroupTopicReply,
+    postReply: NotifyType.GroupPostReply,
+  },
+});
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function setup(app: App) {
@@ -533,56 +545,19 @@ export async function setup(app: App) {
       if (!group) {
         throw new NotFoundError(`group ${topic.gid}`);
       }
-      const replies = await db
-        .select()
-        .from(schema.chiiGroupPosts)
-        .where(op.eq(schema.chiiGroupPosts.mid, topicID))
-        .orderBy(op.asc(schema.chiiGroupPosts.id));
       const viewerID = auth.login ? auth.userID : undefined;
-      const uids = [topic.uid, ...replies.map((x) => x.uid)];
-      const users = await fetcher.fetchSlimUsersByIDs(uids, viewerID);
+      const replies = await groupPostService.getReplies(topicID, viewerID);
+      const users = await fetcher.fetchSlimUsersByIDs([topic.uid], viewerID);
       const creator = users[topic.uid];
       if (!creator) {
         throw new UnexpectedNotFoundError(`user ${topic.uid}`);
-      }
-      const subReplies: Record<number, res.IReplyBase[]> = {};
-      const reactions = await Reaction.fetchByMainID(topicID, LikeType.GroupReply);
-      for (const x of replies) {
-        if (x.related === 0) {
-          continue;
-        }
-        if (!CanViewTopicReply(x.state)) {
-          x.content = '';
-        }
-        const sub = convert.toGroupTopicReply(x);
-        sub.creator = users[sub.creatorID];
-        sub.reactions = reactions[x.id] ?? [];
-        const subR = subReplies[x.related] ?? [];
-        subR.push(sub);
-        subReplies[x.related] = subR;
-      }
-      const topLevelReplies: res.IReply[] = [];
-      for (const x of replies) {
-        if (x.related !== 0) {
-          continue;
-        }
-        if (!CanViewTopicReply(x.state)) {
-          x.content = '';
-        }
-        const reply = {
-          ...convert.toGroupTopicReply(x),
-          creator: users[x.uid],
-          replies: subReplies[x.id] ?? [],
-          reactions: reactions[x.id] ?? [],
-        };
-        topLevelReplies.push(reply);
       }
 
       return {
         ...convert.toGroupTopic(topic),
         group,
         creator,
-        replies: topLevelReplies,
+        replies,
       };
     },
   );
@@ -687,32 +662,11 @@ export async function setup(app: App) {
       },
     },
     async ({ auth, params: { postID } }) => {
-      const [post] = await db
-        .select()
-        .from(schema.chiiGroupPosts)
-        .where(op.eq(schema.chiiGroupPosts.id, postID))
-        .limit(1);
-      if (!post) {
-        throw new NotFoundError(`post ${postID}`);
-      }
-      const [topic] = await db
-        .select()
-        .from(schema.chiiGroupTopics)
-        .where(op.eq(schema.chiiGroupTopics.id, post.mid))
-        .limit(1);
-      if (!topic) {
-        throw new UnexpectedNotFoundError(`topic ${post.mid}`);
-      }
       const viewerID = auth.login ? auth.userID : undefined;
-      const users = await fetcher.fetchSlimUsersByIDs([post.uid, topic.uid], viewerID);
-      const creator = users[post.uid];
-      if (!creator) {
-        throw new UnexpectedNotFoundError(`user ${post.uid}`);
-      }
-      const topicCreator = users[topic.uid];
-      if (!topicCreator) {
-        throw new UnexpectedNotFoundError(`user ${topic.uid}`);
-      }
+      const { post, topic, creator, topicCreator } = await groupPostService.getPost(
+        postID,
+        viewerID,
+      );
       return {
         id: post.id,
         creatorID: post.uid,
@@ -721,7 +675,7 @@ export async function setup(app: App) {
         content: post.content,
         state: post.state,
         topic: {
-          ...convert.toGroupTopic(topic),
+          ...convert.toGroupTopic(topic as orm.IGroupTopic),
           creator: topicCreator,
           replies: topic.replies,
         },
@@ -751,21 +705,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('liking a group post')],
     },
     async ({ auth, params: { postID }, body: { value } }) => {
-      const [post] = await db
-        .select({ mid: schema.chiiGroupPosts.mid })
-        .from(schema.chiiGroupPosts)
-        .where(op.eq(schema.chiiGroupPosts.id, postID))
-        .limit(1);
-      if (!post) {
-        throw new NotFoundError(`post ${postID}`);
-      }
-      await Reaction.add({
-        type: LikeType.GroupReply,
-        mid: post.mid,
-        rid: postID,
-        uid: auth.userID,
-        value,
-      });
+      await groupPostService.like(auth, postID, value);
       return {};
     },
   );
@@ -788,11 +728,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('liking a group post')],
     },
     async ({ auth, params: { postID } }) => {
-      await Reaction.delete({
-        type: LikeType.GroupReply,
-        rid: postID,
-        uid: auth.userID,
-      });
+      await groupPostService.unlike(auth, postID);
       return {};
     },
   );
@@ -816,61 +752,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('edit a post')],
     },
     async ({ auth, body: { content }, params: { postID } }) => {
-      if (auth.permission.ban_post) {
-        throw new NotAllowedError('edit reply');
-      }
-      if (!Dam.allCharacterPrintable(content)) {
-        throw new BadRequestError('content contains invalid invisible character');
-      }
-
-      const [post] = await db
-        .select()
-        .from(schema.chiiGroupPosts)
-        .where(op.eq(schema.chiiGroupPosts.id, postID))
-        .limit(1);
-      if (!post) {
-        throw new NotFoundError(`post ${postID}`);
-      }
-
-      if (post.uid !== auth.userID) {
-        throw new NotAllowedError('edit reply not created by you');
-      }
-
-      const [topic] = await db
-        .select()
-        .from(schema.chiiGroupTopics)
-        .where(op.eq(schema.chiiGroupTopics.id, post.mid))
-        .limit(1);
-      if (!topic) {
-        throw new UnexpectedNotFoundError(`topic ${post.mid}`);
-      }
-      if (topic.state === CommentState.AdminCloseTopic) {
-        throw new NotAllowedError('edit reply in a closed topic');
-      }
-      if (([CommentState.AdminDelete, CommentState.UserDelete] as number[]).includes(post.state)) {
-        throw new NotAllowedError('edit a deleted reply');
-      }
-
-      const [reply] = await db
-        .select()
-        .from(schema.chiiGroupPosts)
-        .where(
-          op.and(
-            op.eq(schema.chiiGroupPosts.mid, topic.id),
-            op.eq(schema.chiiGroupPosts.related, postID),
-          ),
-        )
-        .limit(1);
-      if (reply) {
-        throw new NotAllowedError('edit a post with reply');
-      }
-
-      await rateLimit(LimitAction.Reply, auth.userID);
-      await db
-        .update(schema.chiiGroupPosts)
-        .set({ content })
-        .where(op.eq(schema.chiiGroupPosts.id, postID));
-
+      await groupPostService.update(auth, postID, content);
       return {};
     },
   );
@@ -893,25 +775,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('delete a post')],
     },
     async ({ auth, params: { postID } }) => {
-      const [post] = await db
-        .select()
-        .from(schema.chiiGroupPosts)
-        .where(op.eq(schema.chiiGroupPosts.id, postID))
-        .limit(1);
-      if (!post) {
-        throw new NotFoundError(`post ${postID}`);
-      }
-
-      if (post.uid !== auth.userID) {
-        throw new NotAllowedError('delete reply not created by you');
-      }
-
-      await rateLimit(LimitAction.Reply, auth.userID);
-      await db
-        .update(schema.chiiGroupPosts)
-        .set({ state: CommentState.UserDelete })
-        .where(op.eq(schema.chiiGroupPosts.id, postID));
-
+      await groupPostService.delete(auth, postID);
       return {};
     },
   );
@@ -936,12 +800,6 @@ export async function setup(app: App) {
       preHandler: [requireLogin('creating a reply'), requireTurnstileToken()],
     },
     async ({ auth, params: { topicID }, body: { content, replyTo = 0 } }) => {
-      if (auth.permission.ban_post) {
-        throw new NotAllowedError('create reply');
-      }
-      if (!Dam.allCharacterPrintable(content)) {
-        throw new BadRequestError('content contains invalid invisible character');
-      }
       const [topic] = await db
         .select()
         .from(schema.chiiGroupTopics)
@@ -950,84 +808,21 @@ export async function setup(app: App) {
       if (!topic) {
         throw new NotFoundError(`topic ${topicID}`);
       }
-      if (topic.state === CommentState.AdminCloseTopic) {
-        throw new NotAllowedError('reply to a closed topic');
-      }
 
-      const [group] = await db
-        .select()
-        .from(schema.chiiGroups)
-        .where(op.eq(schema.chiiGroups.id, topic.gid))
-        .limit(1);
-      if (!group) {
-        throw new UnexpectedNotFoundError(`group ${topic.gid}`);
-      }
-      if (!group.accessible && !(await isMemberInGroup(group.id, auth.userID))) {
-        throw new NotJoinPrivateGroupError(group.name);
-      }
-
-      let notifyUserID = topic.uid;
-      if (replyTo) {
-        const [parent] = await db
+      return await groupPostService.create(auth, topic, content, replyTo, async (topic) => {
+        const gTopic = topic as orm.IGroupTopic;
+        const [group] = await db
           .select()
-          .from(schema.chiiGroupPosts)
-          .where(op.eq(schema.chiiGroupPosts.id, replyTo))
+          .from(schema.chiiGroups)
+          .where(op.eq(schema.chiiGroups.id, gTopic.gid))
           .limit(1);
-        if (!parent) {
-          throw new NotFoundError(`post ${replyTo}`);
+        if (!group) {
+          throw new UnexpectedNotFoundError(`group ${gTopic.gid}`);
         }
-        if (!canReplyPost(parent.state)) {
-          throw new NotAllowedError('reply to a admin action post');
+        if (!group.accessible && !(await isMemberInGroup(group.id, auth.userID))) {
+          throw new NotJoinPrivateGroupError(group.name);
         }
-        notifyUserID = parent.uid;
-      }
-
-      await rateLimit(LimitAction.Reply, auth.userID);
-
-      const createdAt = DateTime.now().toUnixInteger();
-
-      let postID = 0;
-      await db.transaction(async (t) => {
-        const [{ count = 0 } = {}] = await t
-          .select({ count: op.count() })
-          .from(schema.chiiGroupPosts)
-          .where(
-            op.and(
-              op.eq(schema.chiiGroupPosts.mid, topicID),
-              op.eq(schema.chiiGroupPosts.state, CommentState.Normal),
-            ),
-          );
-        const [{ insertId }] = await t.insert(schema.chiiGroupPosts).values({
-          mid: topicID,
-          uid: auth.userID,
-          related: replyTo,
-          content,
-          state: CommentState.Normal,
-          createdAt,
-        });
-        postID = insertId;
-        const topicUpdate: Record<string, number> = {
-          replies: count,
-        };
-        if (topic.state !== CommentState.AdminSilentTopic) {
-          topicUpdate.updatedAt = createdAt;
-        }
-        await t
-          .update(schema.chiiGroupTopics)
-          .set(topicUpdate)
-          .where(op.eq(schema.chiiGroupTopics.id, topicID));
-        await Notify.create(t, {
-          destUserID: notifyUserID,
-          sourceUserID: auth.userID,
-          createdAt,
-          type: replyTo === 0 ? NotifyType.GroupTopicReply : NotifyType.GroupPostReply,
-          relatedID: postID,
-          mainID: topic.id,
-          title: topic.title,
-        });
       });
-
-      return { id: postID };
     },
   );
 }

--- a/routes/private/routes/index.ts
+++ b/routes/private/routes/index.ts
@@ -666,7 +666,7 @@ export async function setup(app: App) {
           indexID: t.Integer(),
         }),
         response: {
-          200: t.Array(res.Comment),
+          200: t.Array(res.Ref(res.Comment)),
           404: res.Ref(res.Error, {
             'x-examples': formatErrors(new NotFoundError('index')),
           }),

--- a/routes/private/routes/person.ts
+++ b/routes/private/routes/person.ts
@@ -422,7 +422,7 @@ export async function setup(app: App) {
           personID: t.Integer(),
         }),
         response: {
-          200: t.Array(res.Comment),
+          200: t.Array(res.Ref(res.Comment)),
           404: res.Ref(res.Error, {
             'x-examples': formatErrors(new NotFoundError('person')),
           }),
@@ -543,7 +543,7 @@ export async function setup(app: App) {
           photoID: t.Integer(),
         }),
         response: {
-          200: t.Array(res.Comment),
+          200: t.Array(res.Ref(res.Comment)),
           404: res.Ref(res.Error),
         },
       },

--- a/routes/private/routes/subject.test.ts
+++ b/routes/private/routes/subject.test.ts
@@ -320,6 +320,99 @@ describe('subject topics', () => {
     expect(res.json()).toMatchSnapshot();
   });
 
+  test('should get subject topic with nested replies', async () => {
+    await db.insert(schema.chiiSubjectPosts).values({
+      mid: testTopicID,
+      uid: testUserID,
+      content: 'Nested Reply',
+      related: testPostID,
+      state: 0,
+      createdAt: 1462335911,
+    });
+
+    const app = createTestServer();
+    await app.register(setup);
+
+    const res = await app.inject(`/subjects/-/topics/${testTopicID}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      id: testTopicID,
+      title: 'Test Topic',
+      creatorID: testUserID,
+      replies: [
+        {
+          id: testTopicPostID,
+          creatorID: testUserID,
+          content: 'Test Topic Content',
+          replies: [],
+        },
+        {
+          id: testPostID,
+          creatorID: testUserID,
+          content: 'Test Reply',
+          replies: [{ creatorID: testUserID, content: 'Nested Reply' }],
+        },
+      ],
+    });
+  });
+
+  test('should like and unlike subject post', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: testUserID,
+      },
+    });
+    await app.register(setup);
+
+    const likeRes = await app.inject({
+      url: `/subjects/-/posts/${testPostID}/like`,
+      method: 'put',
+      payload: { value: 0 },
+    });
+    expect(likeRes.statusCode).toBe(200);
+
+    const [like] = await db
+      .select()
+      .from(schema.chiiLikes)
+      .where(
+        op.and(
+          op.eq(schema.chiiLikes.type, LikeType.SubjectReply),
+          op.eq(schema.chiiLikes.relatedID, testPostID),
+          op.eq(schema.chiiLikes.uid, testUserID),
+        ),
+      );
+    expect(like).toMatchObject({ value: 0, deleted: false });
+
+    const unlikeRes = await app.inject({
+      url: `/subjects/-/posts/${testPostID}/like`,
+      method: 'delete',
+    });
+    expect(unlikeRes.statusCode).toBe(200);
+
+    const [unliked] = await db
+      .select()
+      .from(schema.chiiLikes)
+      .where(
+        op.and(
+          op.eq(schema.chiiLikes.type, LikeType.SubjectReply),
+          op.eq(schema.chiiLikes.relatedID, testPostID),
+          op.eq(schema.chiiLikes.uid, testUserID),
+        ),
+      );
+    expect(unliked?.deleted).toBe(true);
+
+    await db
+      .delete(schema.chiiLikes)
+      .where(
+        op.and(
+          op.eq(schema.chiiLikes.type, LikeType.SubjectReply),
+          op.eq(schema.chiiLikes.relatedID, testPostID),
+        ),
+      );
+  });
+
   test('should include friendship in subject post', async () => {
     const viewerID = 900_108;
     const cacheKey = getFriendsCacheKey(viewerID);

--- a/routes/private/routes/subject.ts
+++ b/routes/private/routes/subject.ts
@@ -1754,7 +1754,7 @@ export async function setup(app: App) {
         content: post.content,
         state: post.state,
         topic: {
-          ...convert.toSubjectTopic(topic as orm.ISubjectTopic),
+          ...convert.toSubjectTopic(topic),
           creator: topicCreator,
           replies: topic.replies,
         },

--- a/routes/private/routes/subject.ts
+++ b/routes/private/routes/subject.ts
@@ -7,7 +7,7 @@ import { Dam, dam } from '@app/lib/dam.ts';
 import { BadRequestError, NotFoundError, UnexpectedNotFoundError } from '@app/lib/error.ts';
 import { IndexRelatedCategory } from '@app/lib/index/types';
 import { LikeType, Reaction } from '@app/lib/like';
-import { Notify, NotifyType } from '@app/lib/notify.ts';
+import { NotifyType } from '@app/lib/notify.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
 import { getEpStatus } from '@app/lib/subject/ep';
 import type { SubjectFilter, SubjectSort } from '@app/lib/subject/type.ts';
@@ -18,8 +18,9 @@ import {
 } from '@app/lib/subject/type.ts';
 import { updateSubjectCollectionCounts, updateSubjectRating } from '@app/lib/subject/utils.ts';
 import { AsyncTimelineWriter } from '@app/lib/timeline/writer.ts';
-import { CanViewTopicContent, CanViewTopicReply } from '@app/lib/topic/display.ts';
-import { canEditTopic, canReplyPost } from '@app/lib/topic/state';
+import { CanViewTopicContent } from '@app/lib/topic/display.ts';
+import { TopicPostService } from '@app/lib/topic/post.ts';
+import { canEditTopic } from '@app/lib/topic/state';
 import { CommentState, TopicDisplay } from '@app/lib/topic/type.ts';
 import * as convert from '@app/lib/types/convert.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
@@ -69,6 +70,16 @@ function toSubjectRec(
     count: rec.count,
   };
 }
+
+const subjectPostService = new TopicPostService({
+  table: schema.chiiSubjectPosts,
+  topicTable: schema.chiiSubjectTopics,
+  likeType: LikeType.SubjectReply,
+  notifyTypes: {
+    topicReply: NotifyType.SubjectTopicReply,
+    postReply: NotifyType.SubjectPostReply,
+  },
+});
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function setup(app: App) {
@@ -1613,55 +1624,18 @@ export async function setup(app: App) {
       if (!subject) {
         throw new NotFoundError(`subject ${topic.subjectID}`);
       }
-      const replies = await db
-        .select()
-        .from(schema.chiiSubjectPosts)
-        .where(op.eq(schema.chiiSubjectPosts.mid, topicID))
-        .orderBy(op.asc(schema.chiiSubjectPosts.id));
       const viewerID = auth.login ? auth.userID : undefined;
-      const uids = [topic.uid, ...replies.map((x) => x.uid)];
-      const users = await fetcher.fetchSlimUsersByIDs(uids, viewerID);
+      const replies = await subjectPostService.getReplies(topicID, viewerID);
+      const users = await fetcher.fetchSlimUsersByIDs([topic.uid], viewerID);
       const creator = users[topic.uid];
       if (!creator) {
         throw new NotFoundError(`user ${topic.uid}`);
-      }
-      const subReplies: Record<number, res.IReplyBase[]> = {};
-      const reactions = await Reaction.fetchByMainID(topicID, LikeType.SubjectReply);
-      for (const x of replies) {
-        if (x.related === 0) {
-          continue;
-        }
-        if (!CanViewTopicReply(x.state)) {
-          x.content = '';
-        }
-        const sub = convert.toSubjectTopicReply(x);
-        sub.creator = users[sub.creatorID];
-        sub.reactions = reactions[x.id] ?? [];
-        const subR = subReplies[x.related] ?? [];
-        subR.push(sub);
-        subReplies[x.related] = subR;
-      }
-      const topLevelReplies: res.IReply[] = [];
-      for (const x of replies) {
-        if (x.related !== 0) {
-          continue;
-        }
-        if (!CanViewTopicReply(x.state)) {
-          x.content = '';
-        }
-        const reply = {
-          ...convert.toSubjectTopicReply(x),
-          creator: users[x.uid],
-          replies: subReplies[x.id] ?? [],
-          reactions: reactions[x.id] ?? [],
-        };
-        topLevelReplies.push(reply);
       }
       return {
         ...convert.toSubjectTopic(topic),
         subject,
         creator,
-        replies: topLevelReplies,
+        replies,
       };
     },
   );
@@ -1767,32 +1741,11 @@ export async function setup(app: App) {
       },
     },
     async ({ auth, params: { postID } }) => {
-      const [post] = await db
-        .select()
-        .from(schema.chiiSubjectPosts)
-        .where(op.eq(schema.chiiSubjectPosts.id, postID))
-        .limit(1);
-      if (!post) {
-        throw new NotFoundError(`post ${postID}`);
-      }
-      const [topic] = await db
-        .select()
-        .from(schema.chiiSubjectTopics)
-        .where(op.eq(schema.chiiSubjectTopics.id, post.mid))
-        .limit(1);
-      if (!topic) {
-        throw new UnexpectedNotFoundError(`topic ${post.mid}`);
-      }
       const viewerID = auth.login ? auth.userID : undefined;
-      const users = await fetcher.fetchSlimUsersByIDs([post.uid, topic.uid], viewerID);
-      const creator = users[post.uid];
-      if (!creator) {
-        throw new UnexpectedNotFoundError(`user ${post.uid}`);
-      }
-      const topicCreator = users[topic.uid];
-      if (!topicCreator) {
-        throw new UnexpectedNotFoundError(`user ${topic.uid}`);
-      }
+      const { post, topic, creator, topicCreator } = await subjectPostService.getPost(
+        postID,
+        viewerID,
+      );
       return {
         id: post.id,
         creatorID: post.uid,
@@ -1801,7 +1754,7 @@ export async function setup(app: App) {
         content: post.content,
         state: post.state,
         topic: {
-          ...convert.toSubjectTopic(topic),
+          ...convert.toSubjectTopic(topic as orm.ISubjectTopic),
           creator: topicCreator,
           replies: topic.replies,
         },
@@ -1831,21 +1784,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('liking a subject post')],
     },
     async ({ auth, params: { postID }, body: { value } }) => {
-      const [post] = await db
-        .select({ mid: schema.chiiSubjectPosts.mid })
-        .from(schema.chiiSubjectPosts)
-        .where(op.eq(schema.chiiSubjectPosts.id, postID))
-        .limit(1);
-      if (!post) {
-        throw new NotFoundError(`post ${postID}`);
-      }
-      await Reaction.add({
-        type: LikeType.SubjectReply,
-        mid: post.mid,
-        rid: postID,
-        uid: auth.userID,
-        value,
-      });
+      await subjectPostService.like(auth, postID, value);
       return {};
     },
   );
@@ -1868,11 +1807,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('liking a subject post')],
     },
     async ({ auth, params: { postID } }) => {
-      await Reaction.delete({
-        type: LikeType.SubjectReply,
-        rid: postID,
-        uid: auth.userID,
-      });
+      await subjectPostService.unlike(auth, postID);
       return {};
     },
   );
@@ -1896,61 +1831,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('editing a post')],
     },
     async ({ auth, body: { content }, params: { postID } }) => {
-      if (auth.permission.ban_post) {
-        throw new NotAllowedError('edit reply');
-      }
-      if (!Dam.allCharacterPrintable(content)) {
-        throw new BadRequestError('content contains invalid invisible character');
-      }
-
-      const [post] = await db
-        .select()
-        .from(schema.chiiSubjectPosts)
-        .where(op.eq(schema.chiiSubjectPosts.id, postID))
-        .limit(1);
-      if (!post) {
-        throw new NotFoundError(`post ${postID}`);
-      }
-
-      if (post.uid !== auth.userID) {
-        throw new NotAllowedError('edit reply not created by you');
-      }
-
-      const [topic] = await db
-        .select()
-        .from(schema.chiiSubjectTopics)
-        .where(op.eq(schema.chiiSubjectTopics.id, post.mid))
-        .limit(1);
-      if (!topic) {
-        throw new UnexpectedNotFoundError(`topic ${post.mid}`);
-      }
-      if (topic.state === CommentState.AdminCloseTopic) {
-        throw new NotAllowedError('edit reply in a closed topic');
-      }
-      if (([CommentState.AdminDelete, CommentState.UserDelete] as number[]).includes(post.state)) {
-        throw new NotAllowedError('edit a deleted reply');
-      }
-
-      const [reply] = await db
-        .select()
-        .from(schema.chiiSubjectPosts)
-        .where(
-          op.and(
-            op.eq(schema.chiiSubjectPosts.mid, topic.id),
-            op.eq(schema.chiiSubjectPosts.related, postID),
-          ),
-        )
-        .limit(1);
-      if (reply) {
-        throw new NotAllowedError('edit a post with reply');
-      }
-
-      await rateLimit(LimitAction.Reply, auth.userID);
-      await db
-        .update(schema.chiiSubjectPosts)
-        .set({ content })
-        .where(op.eq(schema.chiiSubjectPosts.id, postID));
-
+      await subjectPostService.update(auth, postID, content);
       return {};
     },
   );
@@ -1973,25 +1854,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('deleting a post')],
     },
     async ({ auth, params: { postID } }) => {
-      const [post] = await db
-        .select()
-        .from(schema.chiiSubjectPosts)
-        .where(op.eq(schema.chiiSubjectPosts.id, postID))
-        .limit(1);
-      if (!post) {
-        throw new NotFoundError(`post ${postID}`);
-      }
-
-      if (post.uid !== auth.userID) {
-        throw new NotAllowedError('delete reply not created by you');
-      }
-
-      await rateLimit(LimitAction.Reply, auth.userID);
-      await db
-        .update(schema.chiiSubjectPosts)
-        .set({ state: CommentState.UserDelete })
-        .where(op.eq(schema.chiiSubjectPosts.id, postID));
-
+      await subjectPostService.delete(auth, postID);
       return {};
     },
   );
@@ -2016,12 +1879,6 @@ export async function setup(app: App) {
       preHandler: [requireLogin('creating a reply'), requireTurnstileToken()],
     },
     async ({ auth, params: { topicID }, body: { content, replyTo = 0 } }) => {
-      if (auth.permission.ban_post) {
-        throw new NotAllowedError('create reply');
-      }
-      if (!Dam.allCharacterPrintable(content)) {
-        throw new BadRequestError('content contains invalid invisible character');
-      }
       const [topic] = await db
         .select()
         .from(schema.chiiSubjectTopics)
@@ -2030,72 +1887,8 @@ export async function setup(app: App) {
       if (!topic) {
         throw new NotFoundError(`topic ${topicID}`);
       }
-      if (topic.state === CommentState.AdminCloseTopic) {
-        throw new NotAllowedError('reply to a closed topic');
-      }
 
-      let notifyUserID = topic.uid;
-      if (replyTo) {
-        const [parent] = await db
-          .select()
-          .from(schema.chiiSubjectPosts)
-          .where(op.eq(schema.chiiSubjectPosts.id, replyTo))
-          .limit(1);
-        if (!parent) {
-          throw new NotFoundError(`post ${replyTo}`);
-        }
-        if (!canReplyPost(parent.state)) {
-          throw new NotAllowedError('reply to a admin action post');
-        }
-        notifyUserID = parent.uid;
-      }
-
-      await rateLimit(LimitAction.Reply, auth.userID);
-
-      const createdAt = DateTime.now().toUnixInteger();
-
-      let postID = 0;
-      await db.transaction(async (t) => {
-        const [{ count = 0 } = {}] = await t
-          .select({ count: op.count() })
-          .from(schema.chiiSubjectPosts)
-          .where(
-            op.and(
-              op.eq(schema.chiiSubjectPosts.mid, topicID),
-              op.eq(schema.chiiSubjectPosts.state, CommentState.Normal),
-            ),
-          );
-        const [{ insertId }] = await t.insert(schema.chiiSubjectPosts).values({
-          mid: topicID,
-          uid: auth.userID,
-          related: replyTo,
-          content,
-          state: CommentState.Normal,
-          createdAt,
-        });
-        postID = insertId;
-        const topicUpdate: Record<string, number> = {
-          replies: count,
-        };
-        if (topic.state !== CommentState.AdminSilentTopic) {
-          topicUpdate.updatedAt = createdAt;
-        }
-        await t
-          .update(schema.chiiSubjectTopics)
-          .set(topicUpdate)
-          .where(op.eq(schema.chiiSubjectTopics.id, topicID));
-        await Notify.create(t, {
-          destUserID: notifyUserID,
-          sourceUserID: auth.userID,
-          createdAt,
-          type: replyTo === 0 ? NotifyType.SubjectTopicReply : NotifyType.SubjectPostReply,
-          relatedID: postID,
-          mainID: topic.id,
-          title: topic.title,
-        });
-      });
-
-      return { id: postID };
+      return await subjectPostService.create(auth, topic, content, replyTo);
     },
   );
 }

--- a/routes/private/routes/timeline.ts
+++ b/routes/private/routes/timeline.ts
@@ -173,7 +173,7 @@ export async function setup(app: App) {
           timelineID: t.Integer(),
         }),
         response: {
-          200: t.Array(res.Comment),
+          200: t.Array(res.Ref(res.Comment)),
           404: res.Ref(res.Error, {
             'x-examples': formatErrors(new NotFoundError('timeline')),
           }),

--- a/routes/schemas.ts
+++ b/routes/schemas.ts
@@ -75,6 +75,7 @@ function addResponseSchemas(app: App) {
   app.addSchema(res.CharacterSubjectRelation);
   app.addSchema(res.CharacterWikiInfo);
   app.addSchema(res.Comment);
+  app.addSchema(res.CommentBase);
   app.addSchema(res.Episode);
   app.addSchema(res.Error);
   app.addSchema(res.Friend);


### PR DESCRIPTION
## Summary

Two related changes discussed with the frontend repo agent:

1. **Unify duplicated group/subject topic reply logic** — `group.ts` and `subject.ts` had nearly identical inline implementations for reply list / post detail / create / update / delete / like. Extracted into a parameterized `TopicPostService` in `lib/topic/post.ts`, keyed by posts table, topic table, like type and notify types. The group-only private-group membership check is passed in via an optional `preCreateCheck` callback (runs after the closed-topic check, preserving error precedence). **Response shapes are unchanged** (existing snapshots in `group.test.ts` / `subject.test.ts` pass as-is).

2. **OpenAPI `$ref` fix** — `Comment`'s first `Intersect` member now references `CommentBase` instead of inlining it, `CommentBase` is registered as a schema component, and the 8 comment-list endpoints use `Ref(res.Comment)`. Regenerated `openapi.json` so clients (e.g. the frontend's oazapfts codegen) get reusable named types instead of anonymous inlined structures. Response payloads are identical (verified: `CommentBase` fields and `required` array match the previously inlined definition byte-for-byte).

Also removed the now-unused `convert.toGroupTopicReply` / `convert.toSubjectTopicReply`.

## Tests

- `npm run tsc`, eslint: pass
- `group.test.ts` + `subject.test.ts`: 39 tests pass (existing snapshots + 4 new: topic detail GET with nested replies, like/unlike)
- `routes/index.test.ts` (openapi spec up-to-date): pass
- Full suite: 427 pass; the single failure seen once was a turnstile external-API timeout (network flake, passes on retry; unrelated)

## Not included (planned follow-ups)

- Renaming `user` → `creator` and adding `mainID`/`relatedID` to topic replies are intentional breaking changes for a later step (coordinated with the frontend).