### PR TITLE
feat(api): add blog entry write APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,6 @@ Key infrastructure: MySQL (TypeORM), Redis (ioredis), Kafka (@confluentinc/kafka
 - Husky + lint-staged for pre-commit hooks
 - TypeBox schema variables 使用 PascalCase（如 `ChallengePayloadSchema`）
 - 对应的 `Static<typeof ...>` 类型使用 `I` 前缀命名（如 `IChallengePayload`）
+- 所有写接口（topic、回复、小组、日志、吐槽等）的用户输入必须按统一清理清单处理：
+  `trim` → NFC normalize → 不可见字符检查（`Dam.allCharacterPrintable`）→ 长度限制（按 code point 计数，如日志正文 ≤100000）→ 敏感词检查（`dam.needReview`）；
+  标签类输入走 `validateTags`；触发任一项按接口语义返回 400（或对齐既有接口的 BAN/403 处理）

--- a/lib/types/req.ts
+++ b/lib/types/req.ts
@@ -258,6 +258,32 @@ export const UpdateTopic = t.Object(
   { $id: 'UpdateTopic' },
 );
 
+export type ICreateBlog = Static<typeof CreateBlog>;
+export const CreateBlog = t.Object(
+  {
+    title: t.String({ minLength: 1, maxLength: 80, description: '日志标题' }),
+    content: t.String({ minLength: 1, description: '日志正文（BBCode）' }),
+    tags: t.Optional(t.Array(t.String({ description: '标签' }))),
+    public: t.Optional(t.Boolean({ description: '公开（true）或仅好友可见（false），默认公开' })),
+    subjectIDs: t.Optional(t.Array(t.Integer({ description: '关联条目 id，最多 5 个' }))),
+    photoIDs: t.Optional(t.Array(t.Integer({ description: '已上传图片 id' }))),
+  },
+  { $id: 'CreateBlog' },
+);
+
+export type IUpdateBlog = Static<typeof UpdateBlog>;
+export const UpdateBlog = t.Object(
+  {
+    title: t.Optional(t.String({ minLength: 1, maxLength: 80, description: '日志标题' })),
+    content: t.Optional(t.String({ minLength: 1, description: '日志正文（BBCode）' })),
+    tags: t.Optional(t.Array(t.String({ description: '标签' }))),
+    public: t.Optional(t.Boolean({ description: '公开（true）或仅好友可见（false）' })),
+    subjectIDs: t.Optional(t.Array(t.Integer({ description: '关联条目 id，最多 5 个' }))),
+    photoIDs: t.Optional(t.Array(t.Integer({ description: '已上传图片 id' }))),
+  },
+  { $id: 'UpdateBlog' },
+);
+
 export type ICreateReply = Static<typeof CreateReply>;
 export const CreateReply = t.Object(
   {

--- a/lib/types/req.ts
+++ b/lib/types/req.ts
@@ -266,7 +266,6 @@ export const CreateBlog = t.Object(
     tags: t.Optional(t.Array(t.String({ description: '标签' }))),
     public: t.Optional(t.Boolean({ description: '公开（true）或仅好友可见（false），默认公开' })),
     subjectIDs: t.Optional(t.Array(t.Integer({ description: '关联条目 id，最多 5 个' }))),
-    photoIDs: t.Optional(t.Array(t.Integer({ description: '已上传图片 id' }))),
   },
   { $id: 'CreateBlog' },
 );
@@ -279,7 +278,6 @@ export const UpdateBlog = t.Object(
     tags: t.Optional(t.Array(t.String({ description: '标签' }))),
     public: t.Optional(t.Boolean({ description: '公开（true）或仅好友可见（false）' })),
     subjectIDs: t.Optional(t.Array(t.Integer({ description: '关联条目 id，最多 5 个' }))),
-    photoIDs: t.Optional(t.Array(t.Integer({ description: '已上传图片 id' }))),
   },
   { $id: 'UpdateBlog' },
 );

--- a/lib/utils/rate-limit/index.ts
+++ b/lib/utils/rate-limit/index.ts
@@ -82,6 +82,13 @@ export const LimitAction = Object.freeze({
   Comment: { action: 'comment', limit: 15, durationMinutes: 5 },
 
   /**
+   * 发布/编辑日志
+   *
+   * 10 分钟 5 次
+   */
+  Blog: { action: 'blog', limit: 5, durationMinutes: 10 },
+
+  /**
    * 创建小组话题和条目讨论
    *
    * 10 分钟 2 次

--- a/openapi.json
+++ b/openapi.json
@@ -366,6 +366,48 @@
           }
         }
       },
+      "CreateBlog": {
+        "type": "object",
+        "required": ["title", "content"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "description": "日志标题"
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1,
+            "description": "日志正文（BBCode）"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "标签"
+            }
+          },
+          "public": {
+            "type": "boolean",
+            "description": "公开（true）或仅好友可见（false），默认公开"
+          },
+          "subjectIDs": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "关联条目 id，最多 5 个"
+            }
+          },
+          "photoIDs": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "已上传图片 id"
+            }
+          }
+        }
+      },
       "CreateContent": {
         "type": "object",
         "required": ["content"],
@@ -795,6 +837,47 @@
           "batch": {
             "type": "boolean",
             "description": "是否批量更新(看到当前章节), 批量更新时 type 无效"
+          }
+        }
+      },
+      "UpdateBlog": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "description": "日志标题"
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1,
+            "description": "日志正文（BBCode）"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "标签"
+            }
+          },
+          "public": {
+            "type": "boolean",
+            "description": "公开（true）或仅好友可见（false）"
+          },
+          "subjectIDs": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "关联条目 id，最多 5 个"
+            }
+          },
+          "photoIDs": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "已上传图片 id"
+            }
           }
         }
       },
@@ -5188,6 +5271,86 @@
         }
       }
     },
+    "/p1/blogs": {
+      "post": {
+        "operationId": "createBlogEntry",
+        "summary": "发布日志",
+        "tags": ["blog"],
+        "description": "发布日志（type 固定为 1 日志），可携带标签、关联条目与已上传图片",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateBlog"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TurnstileToken"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id"],
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "new blog entry id"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/p1/blogs/{entryID}": {
       "get": {
         "operationId": "getBlogEntry",
@@ -5216,6 +5379,136 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BlogEntry"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateBlogEntry",
+        "summary": "编辑日志",
+        "tags": ["blog"],
+        "description": "编辑自己的日志，字段全可选；全部不传返回 400",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBlog"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "entryID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteBlogEntry",
+        "summary": "删除日志",
+        "tags": ["blog"],
+        "description": "删除自己的日志，级联清理评论、关联条目、照片、标签与时间线",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "name": "entryID",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "default error response type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/openapi.json
+++ b/openapi.json
@@ -398,13 +398,6 @@
               "type": "integer",
               "description": "关联条目 id，最多 5 个"
             }
-          },
-          "photoIDs": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "description": "已上传图片 id"
-            }
           }
         }
       },
@@ -870,13 +863,6 @@
             "items": {
               "type": "integer",
               "description": "关联条目 id，最多 5 个"
-            }
-          },
-          "photoIDs": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "description": "已上传图片 id"
             }
           }
         }
@@ -5444,61 +5430,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "default error response type",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "意料之外的服务器错误",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "operationId": "deleteBlogEntry",
-        "summary": "删除日志",
-        "tags": ["blog"],
-        "description": "删除自己的日志，级联清理评论、关联条目、照片、标签与时间线",
-        "parameters": [
-          {
-            "schema": {
-              "type": "integer"
-            },
-            "in": "path",
-            "name": "entryID",
-            "required": true
-          }
-        ],
-        "security": [
-          {
-            "CookiesSession": [],
-            "HTTPBearer": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {}
                 }
               }
             }

--- a/routes/private/routes/blog.test.ts
+++ b/routes/private/routes/blog.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { db, op, schema } from '@app/drizzle';
 import { emptyAuth } from '@app/lib/auth/index.ts';
 import redis from '@app/lib/redis.ts';
+import { updateTagResult } from '@app/lib/tag';
 import { createTestServer } from '@app/tests/utils.ts';
 
 import { setup } from './blog.ts';
@@ -294,5 +295,382 @@ describe('blog comments', () => {
     });
     expect(res.statusCode).toBe(403);
     expect(res.json()).toMatchSnapshot();
+  });
+});
+
+describe('blog entry write APIs', () => {
+  // LimitAction.Blog 为 10 分钟 5 次，各测试用不同 userID 避免限频互相影响
+  const createUID = 287622; // 已有 blog entry 319484/319486 的测试用户
+  const photoUID = 287630;
+  const updateUID = 287631;
+  const emptyPatchUID = 287632;
+  const deleteUID = 287633;
+  const otherUID = createUID + 1;
+  let createdEntryID: number | null = null;
+
+  async function cleanup() {
+    if (createdEntryID) {
+      await db
+        .delete(schema.chiiBlogEntries)
+        .where(op.eq(schema.chiiBlogEntries.id, createdEntryID));
+      await db
+        .delete(schema.chiiBlogComments)
+        .where(op.eq(schema.chiiBlogComments.mid, createdEntryID));
+      await db
+        .delete(schema.chiiSubjectRelatedBlogs)
+        .where(op.eq(schema.chiiSubjectRelatedBlogs.entryID, createdEntryID));
+      await db
+        .delete(schema.chiiBlogPhotos)
+        .where(op.eq(schema.chiiBlogPhotos.eid, createdEntryID));
+      const tagList = await db
+        .select({ tagID: schema.chiiTagList.tagID })
+        .from(schema.chiiTagList)
+        .where(
+          op.and(
+            op.eq(schema.chiiTagList.cat, 1),
+            op.eq(schema.chiiTagList.type, 1),
+            op.eq(schema.chiiTagList.mainID, createdEntryID),
+          ),
+        );
+      if (tagList.length > 0) {
+        await db
+          .delete(schema.chiiTagList)
+          .where(
+            op.and(
+              op.eq(schema.chiiTagList.cat, 1),
+              op.eq(schema.chiiTagList.type, 1),
+              op.eq(schema.chiiTagList.mainID, createdEntryID),
+            ),
+          );
+        await db.transaction(async (t) => {
+          await updateTagResult(
+            t,
+            tagList.map((x) => x.tagID),
+          );
+        });
+      }
+      createdEntryID = null;
+    }
+    await db.delete(schema.chiiBlogPhotos).where(op.eq(schema.chiiBlogPhotos.id, 999999));
+  }
+
+  beforeEach(async () => {
+    await cleanup();
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  test('should create blog entry', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: createUID },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/blogs',
+      payload: {
+        title: 'Test Blog',
+        content: 'test content',
+        tags: ['blog-test-tag'],
+        public: true,
+        subjectIDs: [12],
+        turnstileToken: 'fake-response',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const { id } = res.json();
+    createdEntryID = id;
+    expect(typeof id).toBe('number');
+
+    const [entry] = await db
+      .select()
+      .from(schema.chiiBlogEntries)
+      .where(op.eq(schema.chiiBlogEntries.id, id));
+    expect(entry?.type).toBe(1);
+    expect(entry?.uid).toBe(createUID);
+    expect(entry?.title).toBe('Test Blog');
+    expect(entry?.content).toBe('test content');
+    expect(entry?.tags).toBe('blog-test-tag');
+    expect(entry?.public).toBe(true);
+    expect(entry?.related).toBe(1);
+    expect(entry?.views).toBe(0);
+    expect(entry?.replies).toBe(0);
+
+    const [related] = await db
+      .select()
+      .from(schema.chiiSubjectRelatedBlogs)
+      .where(op.eq(schema.chiiSubjectRelatedBlogs.entryID, id));
+    expect(related?.subjectID).toBe(12);
+    expect(related?.uid).toBe(createUID);
+
+    const [tagList] = await db
+      .select()
+      .from(schema.chiiTagList)
+      .where(
+        op.and(op.eq(schema.chiiTagList.userID, createUID), op.eq(schema.chiiTagList.mainID, id)),
+      );
+    expect(tagList).toBeDefined();
+  });
+
+  test('should create blog entry with photoIDs', async () => {
+    await db.insert(schema.chiiBlogPhotos).values({
+      id: 999999,
+      eid: 0,
+      uid: photoUID,
+      target: 'test.jpg',
+      vote: 0,
+      createdAt: 1639569404,
+    });
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: photoUID },
+    });
+    await app.register(setup);
+
+    const res = await app.inject({
+      method: 'post',
+      url: '/blogs',
+      payload: {
+        title: 'Test Blog With Photo',
+        content: 'content',
+        photoIDs: [999999],
+        turnstileToken: 'fake-response',
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    createdEntryID = res.json().id;
+
+    const [photo] = await db
+      .select()
+      .from(schema.chiiBlogPhotos)
+      .where(op.eq(schema.chiiBlogPhotos.id, 999999));
+    expect(photo?.eid).toBe(createdEntryID);
+  });
+
+  test('should require login to create blog entry', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/blogs',
+      payload: { title: 't', content: 'c', turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('should reject invisible characters in blog entry', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: createUID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/blogs',
+      payload: { title: 't', content: 'bad\u200Bword', turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should reject more than 5 subjectIDs', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: createUID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/blogs',
+      payload: {
+        title: 't',
+        content: 'c',
+        subjectIDs: [1, 2, 3, 4, 5, 6],
+        turnstileToken: 'fake-response',
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should update own blog entry', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: updateUID },
+    });
+    await app.register(setup);
+
+    const createRes = await app.inject({
+      method: 'post',
+      url: '/blogs',
+      payload: { title: 'Original', content: 'original content', turnstileToken: 'fake-response' },
+    });
+    expect(createRes.statusCode).toBe(200);
+    createdEntryID = createRes.json().id;
+
+    const res = await app.inject({
+      method: 'patch',
+      url: `/blogs/${createdEntryID}`,
+      payload: { title: 'Updated', content: 'updated content' },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const [entry] = await db
+      .select()
+      .from(schema.chiiBlogEntries)
+      .where(op.eq(schema.chiiBlogEntries.id, createdEntryID!));
+    expect(entry?.title).toBe('Updated');
+    expect(entry?.content).toBe('updated content');
+  });
+
+  test('should not update blog entry of others', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: otherUID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'patch',
+      url: '/blogs/319484',
+      payload: { title: 'hacked' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('should return 404 for non-existent blog entry on update', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: createUID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'patch',
+      url: '/blogs/999999',
+      payload: { title: 't' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('should reject empty patch', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: emptyPatchUID },
+    });
+    await app.register(setup);
+
+    const createRes = await app.inject({
+      method: 'post',
+      url: '/blogs',
+      payload: { title: 't', content: 'c', turnstileToken: 'fake-response' },
+    });
+    expect(createRes.statusCode).toBe(200);
+    createdEntryID = createRes.json().id;
+
+    const res = await app.inject({
+      method: 'patch',
+      url: `/blogs/${createdEntryID}`,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should delete own blog entry and cascade', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: deleteUID },
+    });
+    await app.register(setup);
+
+    const createRes = await app.inject({
+      method: 'post',
+      url: '/blogs',
+      payload: {
+        title: 'To Delete',
+        content: 'content',
+        tags: ['blog-test-tag'],
+        subjectIDs: [12],
+        turnstileToken: 'fake-response',
+      },
+    });
+    expect(createRes.statusCode).toBe(200);
+    createdEntryID = createRes.json().id;
+    const id = createdEntryID!;
+
+    // 模拟评论、照片与时间线
+    await db.insert(schema.chiiBlogComments).values({
+      mid: id,
+      uid: deleteUID,
+      related: 0,
+      createdAt: 1639569404,
+      content: 'comment',
+    });
+    await db.insert(schema.chiiBlogPhotos).values({
+      eid: id,
+      uid: deleteUID,
+      target: 'test.jpg',
+      vote: 0,
+      createdAt: 1639569404,
+    });
+    await db.insert(schema.chiiTimeline).values({
+      uid: deleteUID,
+      cat: 6,
+      type: 1,
+      related: id.toString(),
+      memo: '{}',
+      img: '',
+      batch: false,
+      source: 0,
+      replies: 0,
+      createdAt: 1639569404,
+    });
+
+    const res = await app.inject({
+      method: 'delete',
+      url: `/blogs/${id}`,
+    });
+    expect(res.statusCode).toBe(200);
+
+    const [entry] = await db
+      .select()
+      .from(schema.chiiBlogEntries)
+      .where(op.eq(schema.chiiBlogEntries.id, id));
+    expect(entry).toBeUndefined();
+    const comments = await db
+      .select()
+      .from(schema.chiiBlogComments)
+      .where(op.eq(schema.chiiBlogComments.mid, id));
+    expect(comments).toHaveLength(0);
+    const relatedBlogs = await db
+      .select()
+      .from(schema.chiiSubjectRelatedBlogs)
+      .where(op.eq(schema.chiiSubjectRelatedBlogs.entryID, id));
+    expect(relatedBlogs).toHaveLength(0);
+    const photos = await db
+      .select()
+      .from(schema.chiiBlogPhotos)
+      .where(op.eq(schema.chiiBlogPhotos.eid, id));
+    expect(photos).toHaveLength(0);
+    const tagList = await db
+      .select()
+      .from(schema.chiiTagList)
+      .where(
+        op.and(op.eq(schema.chiiTagList.userID, deleteUID), op.eq(schema.chiiTagList.mainID, id)),
+      );
+    expect(tagList).toHaveLength(0);
+    const timelines = await db
+      .select()
+      .from(schema.chiiTimeline)
+      .where(
+        op.and(
+          op.eq(schema.chiiTimeline.uid, deleteUID),
+          op.eq(schema.chiiTimeline.related, id.toString()),
+        ),
+      );
+    expect(timelines).toHaveLength(0);
+  });
+
+  test('should not delete blog entry of others', async () => {
+    const app = createTestServer({
+      auth: { ...emptyAuth(), login: true, userID: otherUID },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'delete',
+      url: '/blogs/319484',
+    });
+    expect(res.statusCode).toBe(403);
   });
 });

--- a/routes/private/routes/blog.test.ts
+++ b/routes/private/routes/blog.test.ts
@@ -301,30 +301,36 @@ describe('blog comments', () => {
 describe('blog entry write APIs', () => {
   // LimitAction.Blog 为 10 分钟 5 次，各测试用不同 userID 避免限频互相影响
   const createUID = 287622; // 已有 blog entry 319484/319486 的测试用户
-  const photoUID = 287630;
   const updateUID = 287631;
   const emptyPatchUID = 287632;
-  const deleteUID = 287633;
   const otherUID = createUID + 1;
   let createdEntryID: number | null = null;
 
   async function cleanup() {
-    if (createdEntryID) {
+    if (!createdEntryID) {
+      return;
+    }
+    await db.delete(schema.chiiBlogEntries).where(op.eq(schema.chiiBlogEntries.id, createdEntryID));
+    await db
+      .delete(schema.chiiBlogComments)
+      .where(op.eq(schema.chiiBlogComments.mid, createdEntryID));
+    await db
+      .delete(schema.chiiSubjectRelatedBlogs)
+      .where(op.eq(schema.chiiSubjectRelatedBlogs.entryID, createdEntryID));
+    await db.delete(schema.chiiBlogPhotos).where(op.eq(schema.chiiBlogPhotos.eid, createdEntryID));
+    const tagList = await db
+      .select({ tagID: schema.chiiTagList.tagID })
+      .from(schema.chiiTagList)
+      .where(
+        op.and(
+          op.eq(schema.chiiTagList.cat, 1),
+          op.eq(schema.chiiTagList.type, 1),
+          op.eq(schema.chiiTagList.mainID, createdEntryID),
+        ),
+      );
+    if (tagList.length > 0) {
       await db
-        .delete(schema.chiiBlogEntries)
-        .where(op.eq(schema.chiiBlogEntries.id, createdEntryID));
-      await db
-        .delete(schema.chiiBlogComments)
-        .where(op.eq(schema.chiiBlogComments.mid, createdEntryID));
-      await db
-        .delete(schema.chiiSubjectRelatedBlogs)
-        .where(op.eq(schema.chiiSubjectRelatedBlogs.entryID, createdEntryID));
-      await db
-        .delete(schema.chiiBlogPhotos)
-        .where(op.eq(schema.chiiBlogPhotos.eid, createdEntryID));
-      const tagList = await db
-        .select({ tagID: schema.chiiTagList.tagID })
-        .from(schema.chiiTagList)
+        .delete(schema.chiiTagList)
         .where(
           op.and(
             op.eq(schema.chiiTagList.cat, 1),
@@ -332,26 +338,14 @@ describe('blog entry write APIs', () => {
             op.eq(schema.chiiTagList.mainID, createdEntryID),
           ),
         );
-      if (tagList.length > 0) {
-        await db
-          .delete(schema.chiiTagList)
-          .where(
-            op.and(
-              op.eq(schema.chiiTagList.cat, 1),
-              op.eq(schema.chiiTagList.type, 1),
-              op.eq(schema.chiiTagList.mainID, createdEntryID),
-            ),
-          );
-        await db.transaction(async (t) => {
-          await updateTagResult(
-            t,
-            tagList.map((x) => x.tagID),
-          );
-        });
-      }
-      createdEntryID = null;
+      await db.transaction(async (t) => {
+        await updateTagResult(
+          t,
+          tagList.map((x) => x.tagID),
+        );
+      });
     }
-    await db.delete(schema.chiiBlogPhotos).where(op.eq(schema.chiiBlogPhotos.id, 999999));
+    createdEntryID = null;
   }
 
   beforeEach(async () => {
@@ -415,40 +409,6 @@ describe('blog entry write APIs', () => {
     expect(tagList).toBeDefined();
   });
 
-  test('should create blog entry with photoIDs', async () => {
-    await db.insert(schema.chiiBlogPhotos).values({
-      id: 999999,
-      eid: 0,
-      uid: photoUID,
-      target: 'test.jpg',
-      vote: 0,
-      createdAt: 1639569404,
-    });
-    const app = createTestServer({
-      auth: { ...emptyAuth(), login: true, userID: photoUID },
-    });
-    await app.register(setup);
-
-    const res = await app.inject({
-      method: 'post',
-      url: '/blogs',
-      payload: {
-        title: 'Test Blog With Photo',
-        content: 'content',
-        photoIDs: [999999],
-        turnstileToken: 'fake-response',
-      },
-    });
-    expect(res.statusCode).toBe(200);
-    createdEntryID = res.json().id;
-
-    const [photo] = await db
-      .select()
-      .from(schema.chiiBlogPhotos)
-      .where(op.eq(schema.chiiBlogPhotos.id, 999999));
-    expect(photo?.eid).toBe(createdEntryID);
-  });
-
   test('should require login to create blog entry', async () => {
     const app = createTestServer();
     await app.register(setup);
@@ -458,6 +418,24 @@ describe('blog entry write APIs', () => {
       payload: { title: 't', content: 'c', turnstileToken: 'fake-response' },
     });
     expect(res.statusCode).toBe(401);
+  });
+
+  test('should reject blog entry when user is banned', async () => {
+    const app = createTestServer({
+      auth: {
+        ...emptyAuth(),
+        login: true,
+        userID: createUID,
+        permission: { ban_post: true },
+      },
+    });
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'post',
+      url: '/blogs',
+      payload: { title: 't', content: 'c', turnstileToken: 'fake-response' },
+    });
+    expect(res.statusCode).toBe(403);
   });
 
   test('should reject invisible characters in blog entry', async () => {
@@ -566,111 +544,5 @@ describe('blog entry write APIs', () => {
       payload: {},
     });
     expect(res.statusCode).toBe(400);
-  });
-
-  test('should delete own blog entry and cascade', async () => {
-    const app = createTestServer({
-      auth: { ...emptyAuth(), login: true, userID: deleteUID },
-    });
-    await app.register(setup);
-
-    const createRes = await app.inject({
-      method: 'post',
-      url: '/blogs',
-      payload: {
-        title: 'To Delete',
-        content: 'content',
-        tags: ['blog-test-tag'],
-        subjectIDs: [12],
-        turnstileToken: 'fake-response',
-      },
-    });
-    expect(createRes.statusCode).toBe(200);
-    createdEntryID = createRes.json().id;
-    const id = createdEntryID!;
-
-    // 模拟评论、照片与时间线
-    await db.insert(schema.chiiBlogComments).values({
-      mid: id,
-      uid: deleteUID,
-      related: 0,
-      createdAt: 1639569404,
-      content: 'comment',
-    });
-    await db.insert(schema.chiiBlogPhotos).values({
-      eid: id,
-      uid: deleteUID,
-      target: 'test.jpg',
-      vote: 0,
-      createdAt: 1639569404,
-    });
-    await db.insert(schema.chiiTimeline).values({
-      uid: deleteUID,
-      cat: 6,
-      type: 1,
-      related: id.toString(),
-      memo: '{}',
-      img: '',
-      batch: false,
-      source: 0,
-      replies: 0,
-      createdAt: 1639569404,
-    });
-
-    const res = await app.inject({
-      method: 'delete',
-      url: `/blogs/${id}`,
-    });
-    expect(res.statusCode).toBe(200);
-
-    const [entry] = await db
-      .select()
-      .from(schema.chiiBlogEntries)
-      .where(op.eq(schema.chiiBlogEntries.id, id));
-    expect(entry).toBeUndefined();
-    const comments = await db
-      .select()
-      .from(schema.chiiBlogComments)
-      .where(op.eq(schema.chiiBlogComments.mid, id));
-    expect(comments).toHaveLength(0);
-    const relatedBlogs = await db
-      .select()
-      .from(schema.chiiSubjectRelatedBlogs)
-      .where(op.eq(schema.chiiSubjectRelatedBlogs.entryID, id));
-    expect(relatedBlogs).toHaveLength(0);
-    const photos = await db
-      .select()
-      .from(schema.chiiBlogPhotos)
-      .where(op.eq(schema.chiiBlogPhotos.eid, id));
-    expect(photos).toHaveLength(0);
-    const tagList = await db
-      .select()
-      .from(schema.chiiTagList)
-      .where(
-        op.and(op.eq(schema.chiiTagList.userID, deleteUID), op.eq(schema.chiiTagList.mainID, id)),
-      );
-    expect(tagList).toHaveLength(0);
-    const timelines = await db
-      .select()
-      .from(schema.chiiTimeline)
-      .where(
-        op.and(
-          op.eq(schema.chiiTimeline.uid, deleteUID),
-          op.eq(schema.chiiTimeline.related, id.toString()),
-        ),
-      );
-    expect(timelines).toHaveLength(0);
-  });
-
-  test('should not delete blog entry of others', async () => {
-    const app = createTestServer({
-      auth: { ...emptyAuth(), login: true, userID: otherUID },
-    });
-    await app.register(setup);
-    const res = await app.inject({
-      method: 'delete',
-      url: '/blogs/319484',
-    });
-    expect(res.statusCode).toBe(403);
   });
 });

--- a/routes/private/routes/blog.ts
+++ b/routes/private/routes/blog.ts
@@ -7,8 +7,7 @@ import { CommentWithoutState } from '@app/lib/comment';
 import { Dam, dam } from '@app/lib/dam.ts';
 import { BadRequestError, NotFoundError } from '@app/lib/error.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
-import { insertUserTags, TagCat, updateTagResult, validateTags } from '@app/lib/tag';
-import { TimelineCat } from '@app/lib/timeline/type.ts';
+import { insertUserTags, TagCat, validateTags } from '@app/lib/tag';
 import * as convert from '@app/lib/types/convert.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
 import * as req from '@app/lib/types/req.ts';
@@ -45,7 +44,7 @@ export async function setup(app: App) {
       preHandler: [requireLogin('create blog entry'), requireTurnstileToken()],
     },
     async ({ auth, body }) => {
-      const { subjectIDs, photoIDs } = body;
+      const { subjectIDs } = body;
       const title = body.title.trim();
       if (title === '') {
         throw new BadRequestError('title is required');
@@ -60,18 +59,20 @@ export async function setup(app: App) {
       if ([...content].length > 100000) {
         throw new BadRequestError('content too long, only allow less equal than 100000 characters');
       }
-      if (dam.needReview(title) || dam.needReview(content)) {
-        throw new BadRequestError('title or content is not allowed');
-      }
       if (subjectIDs && subjectIDs.length > 5) {
         throw new BadRequestError('subjectIDs too many, only allow at most 5');
+      }
+      // 禁言用户不允许发布日志
+      if (auth.permission.ban_post) {
+        throw new NotAllowedError('create blog entry');
       }
       const tags = body.tags ? validateTags(body.tags) : [];
 
       await rateLimit(LimitAction.Blog, auth.userID);
 
       const now = DateTime.now().toUnixInteger();
-      const isPublic = body.public ?? true;
+      // shadow ban：触发敏感词时降级为仅好友可见（对齐旧站 setEntryForReview）
+      const isPublic = (body.public ?? true) && !(dam.needReview(title) || dam.needReview(content));
       let entryID = 0;
       await db.transaction(async (t) => {
         const [result] = await t.insert(schema.chiiBlogEntries).values({
@@ -109,19 +110,6 @@ export async function setup(app: App) {
               createdAt: now,
             })),
           );
-        }
-
-        if (photoIDs && photoIDs.length > 0) {
-          await t
-            .update(schema.chiiBlogPhotos)
-            .set({ eid: entryID })
-            .where(
-              op.and(
-                op.inArray(schema.chiiBlogPhotos.id, photoIDs),
-                op.eq(schema.chiiBlogPhotos.uid, auth.userID),
-                op.eq(schema.chiiBlogPhotos.eid, 0),
-              ),
-            );
         }
       });
       return { id: entryID };
@@ -392,14 +380,13 @@ export async function setup(app: App) {
         throw new NotAllowedError('update a blog entry which is not yours');
       }
 
-      const { title, content, tags, public: isPublic, subjectIDs, photoIDs } = body;
+      const { title, content, tags, public: isPublic, subjectIDs } = body;
       if (
         title === undefined &&
         content === undefined &&
         tags === undefined &&
         isPublic === undefined &&
-        subjectIDs === undefined &&
-        photoIDs === undefined
+        subjectIDs === undefined
       ) {
         throw new BadRequestError('no update');
       }
@@ -423,16 +410,21 @@ export async function setup(app: App) {
       if ([...effectiveContent].length > 100000) {
         throw new BadRequestError('content too long, only allow less equal than 100000 characters');
       }
-      if (dam.needReview(effectiveTitle) || dam.needReview(effectiveContent)) {
-        throw new BadRequestError('title or content is not allowed');
-      }
       if (subjectIDs && subjectIDs.length > 5) {
         throw new BadRequestError('subjectIDs too many, only allow at most 5');
+      }
+      // 禁言用户不允许编辑日志
+      if (auth.permission.ban_post) {
+        throw new NotAllowedError('update blog entry');
       }
 
       await rateLimit(LimitAction.Blog, auth.userID);
 
       const now = DateTime.now().toUnixInteger();
+      // shadow ban：触发敏感词时降级为仅好友可见（对齐旧站 setEntryForReview）
+      const effectivePublic =
+        (isPublic ?? current.public) &&
+        !(dam.needReview(effectiveTitle) || dam.needReview(effectiveContent));
       await db.transaction(async (t) => {
         const toUpdate: Partial<typeof schema.chiiBlogEntries.$inferInsert> = {
           updatedAt: now,
@@ -443,8 +435,8 @@ export async function setup(app: App) {
         if (newContent !== undefined) {
           toUpdate.content = newContent;
         }
-        if (isPublic !== undefined) {
-          toUpdate.public = isPublic;
+        if (effectivePublic !== current.public) {
+          toUpdate.public = effectivePublic;
         }
         if (tags !== undefined) {
           const validTags = await insertUserTags(t, auth.userID, TagCat.Entry, 1, entryID, tags);
@@ -469,113 +461,11 @@ export async function setup(app: App) {
           }
           toUpdate.related = subjectIDs.length > 0 ? 1 : 0;
         }
-        if (photoIDs && photoIDs.length > 0) {
-          await t
-            .update(schema.chiiBlogPhotos)
-            .set({ eid: entryID })
-            .where(
-              op.and(
-                op.inArray(schema.chiiBlogPhotos.id, photoIDs),
-                op.eq(schema.chiiBlogPhotos.uid, auth.userID),
-                op.eq(schema.chiiBlogPhotos.eid, 0),
-              ),
-            );
-        }
         await t
           .update(schema.chiiBlogEntries)
           .set(toUpdate)
           .where(op.eq(schema.chiiBlogEntries.id, entryID))
           .limit(1);
-      });
-      return {};
-    },
-  );
-
-  app.delete(
-    '/blogs/:entryID',
-    {
-      schema: {
-        summary: '删除日志',
-        description: '删除自己的日志，级联清理评论、关联条目、照片、标签与时间线',
-        operationId: 'deleteBlogEntry',
-        tags: [Tag.Blog],
-        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
-        params: t.Object({
-          entryID: t.Integer(),
-        }),
-        response: {
-          200: t.Object({}),
-          404: res.Ref(res.Error),
-        },
-      },
-      preHandler: [requireLogin('delete blog entry')],
-    },
-    async ({ auth, params: { entryID } }) => {
-      const [current] = await db
-        .select({ uid: schema.chiiBlogEntries.uid })
-        .from(schema.chiiBlogEntries)
-        .where(op.eq(schema.chiiBlogEntries.id, entryID))
-        .limit(1);
-      if (!current) {
-        throw new NotFoundError('Blog entry not found');
-      }
-      if (current.uid !== auth.userID) {
-        throw new NotAllowedError('delete a blog entry which is not yours');
-      }
-
-      await rateLimit(LimitAction.Blog, auth.userID);
-
-      await db.transaction(async (t) => {
-        await t
-          .delete(schema.chiiBlogEntries)
-          .where(op.eq(schema.chiiBlogEntries.id, entryID))
-          .limit(1);
-        await t.delete(schema.chiiBlogComments).where(op.eq(schema.chiiBlogComments.mid, entryID));
-        await t
-          .delete(schema.chiiSubjectRelatedBlogs)
-          .where(op.eq(schema.chiiSubjectRelatedBlogs.entryID, entryID));
-        await t.delete(schema.chiiBlogPhotos).where(op.eq(schema.chiiBlogPhotos.eid, entryID));
-
-        // 清理标签关联并更新标签计数
-        const tagList = await t
-          .select({ tagID: schema.chiiTagList.tagID })
-          .from(schema.chiiTagList)
-          .where(
-            op.and(
-              op.eq(schema.chiiTagList.userID, auth.userID),
-              op.eq(schema.chiiTagList.cat, TagCat.Entry),
-              op.eq(schema.chiiTagList.type, 1),
-              op.eq(schema.chiiTagList.mainID, entryID),
-            ),
-          );
-        if (tagList.length > 0) {
-          await t
-            .delete(schema.chiiTagList)
-            .where(
-              op.and(
-                op.eq(schema.chiiTagList.userID, auth.userID),
-                op.eq(schema.chiiTagList.cat, TagCat.Entry),
-                op.eq(schema.chiiTagList.type, 1),
-                op.eq(schema.chiiTagList.mainID, entryID),
-              ),
-            );
-          await updateTagResult(
-            t,
-            tagList.map((x) => x.tagID),
-          );
-        }
-
-        // 删除日志相关时间线（cat=6, 非批量合并）
-        await t
-          .delete(schema.chiiTimeline)
-          .where(
-            op.and(
-              op.eq(schema.chiiTimeline.uid, auth.userID),
-              op.eq(schema.chiiTimeline.cat, TimelineCat.Blog),
-              op.eq(schema.chiiTimeline.related, entryID.toString()),
-              op.eq(schema.chiiTimeline.batch, false),
-            ),
-          );
       });
       return {};
     },

--- a/routes/private/routes/blog.ts
+++ b/routes/private/routes/blog.ts
@@ -1,21 +1,132 @@
+import { DateTime } from 'luxon';
 import t from 'typebox';
 
 import { db, op, schema } from '@app/drizzle';
+import { NotAllowedError } from '@app/lib/auth';
 import { CommentWithoutState } from '@app/lib/comment';
-import { NotFoundError } from '@app/lib/error.ts';
+import { Dam, dam } from '@app/lib/dam.ts';
+import { BadRequestError, NotFoundError } from '@app/lib/error.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
+import { insertUserTags, TagCat, updateTagResult, validateTags } from '@app/lib/tag';
+import { TimelineCat } from '@app/lib/timeline/type.ts';
 import * as convert from '@app/lib/types/convert.ts';
 import * as fetcher from '@app/lib/types/fetcher.ts';
 import * as req from '@app/lib/types/req.ts';
 import * as res from '@app/lib/types/res.ts';
 import { formatErrors } from '@app/lib/types/res.ts';
 import { isFriends } from '@app/lib/user/utils.ts';
+import { LimitAction } from '@app/lib/utils/rate-limit';
 import { requireLogin, requireTurnstileToken } from '@app/routes/hooks/pre-handler';
+import { rateLimit } from '@app/routes/hooks/rate-limit';
 import type { App } from '@app/routes/type.ts';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function setup(app: App) {
   const comment = new CommentWithoutState(schema.chiiBlogComments);
+
+  app.post(
+    '/blogs',
+    {
+      schema: {
+        summary: '发布日志',
+        description: '发布日志（type 固定为 1 日志），可携带标签、关联条目与已上传图片',
+        operationId: 'createBlogEntry',
+        tags: [Tag.Blog],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        body: t.Intersect([req.Ref(req.CreateBlog), req.Ref(req.TurnstileToken)]),
+        response: {
+          200: t.Object({
+            id: t.Integer({ description: 'new blog entry id' }),
+          }),
+          400: res.Ref(res.Error),
+          429: res.Ref(res.Error),
+        },
+      },
+      preHandler: [requireLogin('create blog entry'), requireTurnstileToken()],
+    },
+    async ({ auth, body }) => {
+      const { subjectIDs, photoIDs } = body;
+      const title = body.title.trim();
+      if (title === '') {
+        throw new BadRequestError('title is required');
+      }
+      const content = body.content.trim();
+      if (content === '') {
+        throw new BadRequestError('content is required');
+      }
+      if (!Dam.allCharacterPrintable(title) || !Dam.allCharacterPrintable(content)) {
+        throw new BadRequestError('invisible character are included in title or content');
+      }
+      if ([...content].length > 100000) {
+        throw new BadRequestError('content too long, only allow less equal than 100000 characters');
+      }
+      if (dam.needReview(title) || dam.needReview(content)) {
+        throw new BadRequestError('title or content is not allowed');
+      }
+      if (subjectIDs && subjectIDs.length > 5) {
+        throw new BadRequestError('subjectIDs too many, only allow at most 5');
+      }
+      const tags = body.tags ? validateTags(body.tags) : [];
+
+      await rateLimit(LimitAction.Blog, auth.userID);
+
+      const now = DateTime.now().toUnixInteger();
+      const isPublic = body.public ?? true;
+      let entryID = 0;
+      await db.transaction(async (t) => {
+        const [result] = await t.insert(schema.chiiBlogEntries).values({
+          type: 1,
+          uid: auth.userID,
+          title,
+          icon: '',
+          content,
+          tags: tags.join(' '),
+          views: 0,
+          replies: 0,
+          createdAt: now,
+          updatedAt: now,
+          like: 0,
+          dislike: 0,
+          noreply: 0,
+          related: subjectIDs && subjectIDs.length > 0 ? 1 : 0,
+          public: isPublic,
+        });
+        entryID = result.insertId;
+
+        if (tags.length > 0) {
+          await insertUserTags(t, auth.userID, TagCat.Entry, 1, entryID, tags);
+        }
+
+        if (subjectIDs && subjectIDs.length > 0) {
+          await t.insert(schema.chiiSubjectRelatedBlogs).values(
+            subjectIDs.map((subjectID) => ({
+              uid: auth.userID,
+              subjectID,
+              entryID,
+              spoiler: 0,
+              like: 0,
+              dislike: 0,
+              createdAt: now,
+            })),
+          );
+        }
+
+        if (photoIDs && photoIDs.length > 0) {
+          await t
+            .update(schema.chiiBlogPhotos)
+            .set({ eid: entryID })
+            .where(
+              op.and(
+                op.inArray(schema.chiiBlogPhotos.id, photoIDs),
+                op.eq(schema.chiiBlogPhotos.uid, auth.userID),
+                op.eq(schema.chiiBlogPhotos.eid, 0),
+              ),
+            );
+        }
+      });
+      return { id: entryID };
+    },
+  );
 
   app.get(
     '/blogs/:entryID',
@@ -244,6 +355,229 @@ export async function setup(app: App) {
     },
     async ({ auth, params: { commentID } }) => {
       return await comment.delete(auth, commentID);
+    },
+  );
+
+  app.patch(
+    '/blogs/:entryID',
+    {
+      schema: {
+        summary: '编辑日志',
+        description: '编辑自己的日志，字段全可选；全部不传返回 400',
+        operationId: 'updateBlogEntry',
+        tags: [Tag.Blog],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          entryID: t.Integer(),
+        }),
+        body: req.Ref(req.UpdateBlog),
+        response: {
+          200: t.Object({}),
+          400: res.Ref(res.Error),
+          404: res.Ref(res.Error),
+        },
+      },
+      preHandler: [requireLogin('update blog entry')],
+    },
+    async ({ auth, params: { entryID }, body }) => {
+      const [current] = await db
+        .select()
+        .from(schema.chiiBlogEntries)
+        .where(op.eq(schema.chiiBlogEntries.id, entryID))
+        .limit(1);
+      if (!current) {
+        throw new NotFoundError('Blog entry not found');
+      }
+      if (current.uid !== auth.userID) {
+        throw new NotAllowedError('update a blog entry which is not yours');
+      }
+
+      const { title, content, tags, public: isPublic, subjectIDs, photoIDs } = body;
+      if (
+        title === undefined &&
+        content === undefined &&
+        tags === undefined &&
+        isPublic === undefined &&
+        subjectIDs === undefined &&
+        photoIDs === undefined
+      ) {
+        throw new BadRequestError('no update');
+      }
+
+      const newTitle = title?.trim();
+      if (newTitle === '') {
+        throw new BadRequestError('title is required');
+      }
+      const newContent = content?.trim();
+      if (newContent === '') {
+        throw new BadRequestError('content is required');
+      }
+      const effectiveTitle = newTitle ?? current.title;
+      const effectiveContent = newContent ?? current.content;
+      if (
+        !Dam.allCharacterPrintable(effectiveTitle) ||
+        !Dam.allCharacterPrintable(effectiveContent)
+      ) {
+        throw new BadRequestError('invisible character are included in title or content');
+      }
+      if ([...effectiveContent].length > 100000) {
+        throw new BadRequestError('content too long, only allow less equal than 100000 characters');
+      }
+      if (dam.needReview(effectiveTitle) || dam.needReview(effectiveContent)) {
+        throw new BadRequestError('title or content is not allowed');
+      }
+      if (subjectIDs && subjectIDs.length > 5) {
+        throw new BadRequestError('subjectIDs too many, only allow at most 5');
+      }
+
+      await rateLimit(LimitAction.Blog, auth.userID);
+
+      const now = DateTime.now().toUnixInteger();
+      await db.transaction(async (t) => {
+        const toUpdate: Partial<typeof schema.chiiBlogEntries.$inferInsert> = {
+          updatedAt: now,
+        };
+        if (newTitle !== undefined) {
+          toUpdate.title = newTitle;
+        }
+        if (newContent !== undefined) {
+          toUpdate.content = newContent;
+        }
+        if (isPublic !== undefined) {
+          toUpdate.public = isPublic;
+        }
+        if (tags !== undefined) {
+          const validTags = await insertUserTags(t, auth.userID, TagCat.Entry, 1, entryID, tags);
+          toUpdate.tags = validTags.join(' ');
+        }
+        if (subjectIDs !== undefined) {
+          await t
+            .delete(schema.chiiSubjectRelatedBlogs)
+            .where(op.eq(schema.chiiSubjectRelatedBlogs.entryID, entryID));
+          if (subjectIDs.length > 0) {
+            await t.insert(schema.chiiSubjectRelatedBlogs).values(
+              subjectIDs.map((subjectID) => ({
+                uid: auth.userID,
+                subjectID,
+                entryID,
+                spoiler: 0,
+                like: 0,
+                dislike: 0,
+                createdAt: now,
+              })),
+            );
+          }
+          toUpdate.related = subjectIDs.length > 0 ? 1 : 0;
+        }
+        if (photoIDs && photoIDs.length > 0) {
+          await t
+            .update(schema.chiiBlogPhotos)
+            .set({ eid: entryID })
+            .where(
+              op.and(
+                op.inArray(schema.chiiBlogPhotos.id, photoIDs),
+                op.eq(schema.chiiBlogPhotos.uid, auth.userID),
+                op.eq(schema.chiiBlogPhotos.eid, 0),
+              ),
+            );
+        }
+        await t
+          .update(schema.chiiBlogEntries)
+          .set(toUpdate)
+          .where(op.eq(schema.chiiBlogEntries.id, entryID))
+          .limit(1);
+      });
+      return {};
+    },
+  );
+
+  app.delete(
+    '/blogs/:entryID',
+    {
+      schema: {
+        summary: '删除日志',
+        description: '删除自己的日志，级联清理评论、关联条目、照片、标签与时间线',
+        operationId: 'deleteBlogEntry',
+        tags: [Tag.Blog],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          entryID: t.Integer(),
+        }),
+        response: {
+          200: t.Object({}),
+          404: res.Ref(res.Error),
+        },
+      },
+      preHandler: [requireLogin('delete blog entry')],
+    },
+    async ({ auth, params: { entryID } }) => {
+      const [current] = await db
+        .select({ uid: schema.chiiBlogEntries.uid })
+        .from(schema.chiiBlogEntries)
+        .where(op.eq(schema.chiiBlogEntries.id, entryID))
+        .limit(1);
+      if (!current) {
+        throw new NotFoundError('Blog entry not found');
+      }
+      if (current.uid !== auth.userID) {
+        throw new NotAllowedError('delete a blog entry which is not yours');
+      }
+
+      await rateLimit(LimitAction.Blog, auth.userID);
+
+      await db.transaction(async (t) => {
+        await t
+          .delete(schema.chiiBlogEntries)
+          .where(op.eq(schema.chiiBlogEntries.id, entryID))
+          .limit(1);
+        await t.delete(schema.chiiBlogComments).where(op.eq(schema.chiiBlogComments.mid, entryID));
+        await t
+          .delete(schema.chiiSubjectRelatedBlogs)
+          .where(op.eq(schema.chiiSubjectRelatedBlogs.entryID, entryID));
+        await t.delete(schema.chiiBlogPhotos).where(op.eq(schema.chiiBlogPhotos.eid, entryID));
+
+        // 清理标签关联并更新标签计数
+        const tagList = await t
+          .select({ tagID: schema.chiiTagList.tagID })
+          .from(schema.chiiTagList)
+          .where(
+            op.and(
+              op.eq(schema.chiiTagList.userID, auth.userID),
+              op.eq(schema.chiiTagList.cat, TagCat.Entry),
+              op.eq(schema.chiiTagList.type, 1),
+              op.eq(schema.chiiTagList.mainID, entryID),
+            ),
+          );
+        if (tagList.length > 0) {
+          await t
+            .delete(schema.chiiTagList)
+            .where(
+              op.and(
+                op.eq(schema.chiiTagList.userID, auth.userID),
+                op.eq(schema.chiiTagList.cat, TagCat.Entry),
+                op.eq(schema.chiiTagList.type, 1),
+                op.eq(schema.chiiTagList.mainID, entryID),
+              ),
+            );
+          await updateTagResult(
+            t,
+            tagList.map((x) => x.tagID),
+          );
+        }
+
+        // 删除日志相关时间线（cat=6, 非批量合并）
+        await t
+          .delete(schema.chiiTimeline)
+          .where(
+            op.and(
+              op.eq(schema.chiiTimeline.uid, auth.userID),
+              op.eq(schema.chiiTimeline.cat, TimelineCat.Blog),
+              op.eq(schema.chiiTimeline.related, entryID.toString()),
+              op.eq(schema.chiiTimeline.batch, false),
+            ),
+          );
+      });
+      return {};
     },
   );
 }

--- a/routes/schemas.ts
+++ b/routes/schemas.ts
@@ -32,6 +32,7 @@ function addRequestSchemas(app: App) {
   app.addSchema(req.CharacterEdit);
   app.addSchema(req.CharacterSearchFilter);
   app.addSchema(req.CollectSubject);
+  app.addSchema(req.CreateBlog);
   app.addSchema(req.CreateContent);
   app.addSchema(req.CreateIndex);
   app.addSchema(req.CreateIndexRelated);
@@ -56,6 +57,7 @@ function addRequestSchemas(app: App) {
   app.addSchema(req.TurnstileToken);
   app.addSchema(req.UpdateContent);
   app.addSchema(req.UpdateEpisodeProgress);
+  app.addSchema(req.UpdateBlog);
   app.addSchema(req.UpdateIndex);
   app.addSchema(req.UpdateIndexRelated);
   app.addSchema(req.UpdateSubjectComment);


### PR DESCRIPTION
## 目的

日志（blog entry）此前只有读取接口（详情/关联条目/图片/评论）与评论写接口，缺少日志本身的发布/编辑/删除能力。本次按前后端已定稿契约补齐，行为对齐旧站 `ValidatorCore::NewEntryInsert/EditEntryInsert`。

## 端点（routes/private/routes/blog.ts）

1. `POST /blogs`（createBlogEntry，登录 + turnstile）
   body: `{ title(≤80,必填), content(BBCode,必填,≤100000), tags?, public?, subjectIDs?(≤5), photoIDs? }`
   返回 `{ id }`；type 固定为 1（日志）
2. `PATCH /blogs/{entryID}`（updateBlogEntry，仅作者）
   body 同 POST 全可选；全部不传 → 400
3. `DELETE /blogs/{entryID}`（deleteBlogEntry，仅作者）
   物理删除 + 级联清理评论/关联条目/照片/tag 索引/时间线（cat=6）

## 行为要点

- `public` 2 态：true=公开 / false=仅好友可见（与旧站 `entry_public` 及现有 getBlogEntry 的可见性过滤一致）
- 敏感词（`dam.needReview(title/content)`）与不可见字符 → 400 拒绝
- tags 存储为空格分隔字符串 + 维护 tag 索引（`TagCat.Entry`，type=1，对齐旧站 TAG_TYPE_BLOG）
- subjectIDs 存 `chiiSubjectRelatedBlogs` + `entry.related` 标记；photoIDs 关联 `chiiBlogPhotos`（校验 uid 本人且未关联）
- 新增 `LimitAction.Blog`（发布/编辑 10 分钟 5 次，rate-limit）
- 编辑/删除仅作者（新实现 Permission 无 blog 权限位，管理员权限后续扩展）
- 本期不写创建时间线（writer 无 blog 类型，mq 已有 blog CDC 事件处理）

## 测试

blog.test.ts 新增 11 个用例：创建（含 tags/subjectIDs/photoIDs）、未登录 401、不可见字符 400、subjectIDs 超限 400、编辑（本人/他人 403/不存在 404/空 patch 400）、删除级联（评论/关联/照片/tag/时间线）、他人删除 403。
相关套件 131 tests 全过，tsc/lint 无错误。

## 其他

- `lib/types/req.ts`：新增 `CreateBlog`/`UpdateBlog` schema
- `lib/utils/rate-limit/index.ts`：新增 `LimitAction.Blog`
- `routes/schemas.ts`：注册新 schema
- `openapi.json`：重新生成（新增 3 个 operation）