### PR TITLE
feat: add channel subject topics API, read trending topics from cache

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4053,6 +4053,32 @@
           }
         }
       },
+      "ChannelSubjectTopic": {
+        "type": "object",
+        "required": ["id", "title", "replyCount", "updatedAt", "subject"],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "replyCount": {
+            "type": "integer"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "description": "最后回复时间，unix time stamp in seconds"
+          },
+          "creator": {
+            "$ref": "#/components/schemas/SlimUser"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/SlimSubject"
+          }
+        },
+        "title": "ChannelSubjectTopic"
+      },
       "FriendSubjectCollectionActivity": {
         "type": "object",
         "required": ["user", "subject", "collectionType", "updatedAt"],
@@ -4279,32 +4305,6 @@
             "type": "integer"
           }
         }
-      },
-      "ChannelSubjectTopic": {
-        "type": "object",
-        "required": ["id", "title", "replyCount", "updatedAt", "subject"],
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "title": {
-            "type": "string"
-          },
-          "replyCount": {
-            "type": "integer"
-          },
-          "updatedAt": {
-            "type": "integer",
-            "description": "最后回复时间，unix time stamp in seconds"
-          },
-          "creator": {
-            "$ref": "#/components/schemas/SlimUser"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/SlimSubject"
-          }
-        },
-        "title": "ChannelSubjectTopic"
       },
       "SubjectEdit": {
         "type": "object",
@@ -5675,6 +5675,87 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Calendar"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "意料之外的服务器错误",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p1/channels/{type}/topics": {
+      "get": {
+        "operationId": "getChannelSubjectTopics",
+        "summary": "获取频道条目讨论",
+        "tags": ["topic"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "max 100"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "description": "min 0"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/SubjectType"
+            },
+            "in": "path",
+            "name": "type",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "CookiesSession": [],
+            "HTTPBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data", "total"],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ChannelSubjectTopic"
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "limit+offset 为参数的请求表示总条数，page 为参数的请求表示总页数"
+                    }
+                  }
                 }
               }
             }
@@ -15777,17 +15858,9 @@
     "/p1/trending/subjects/topics": {
       "get": {
         "operationId": "getTrendingSubjectTopics",
-        "summary": "获取条目讨论",
+        "summary": "获取热门条目讨论",
         "tags": ["trending"],
         "parameters": [
-          {
-            "schema": {
-              "$ref": "#/components/schemas/SubjectType"
-            },
-            "in": "query",
-            "name": "type",
-            "required": false
-          },
           {
             "schema": {
               "type": "integer",
@@ -15830,7 +15903,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/ChannelSubjectTopic"
+                        "$ref": "#/components/schemas/SubjectTopic"
                       }
                     },
                     "total": {

--- a/routes/private/routes/channel.test.ts
+++ b/routes/private/routes/channel.test.ts
@@ -1,10 +1,35 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
+import { db, op, schema } from '@app/drizzle';
 import { createTestServer } from '@app/tests/utils.ts';
 
 import { setup } from './channel.ts';
 
 describe('channel', () => {
+  const testTopicID = 12345671;
+  const testSubjectID = 12; // 动画
+  const testUserID = 287622;
+
+  beforeEach(async () => {
+    await db.insert(schema.chiiSubjectTopics).values({
+      id: testTopicID,
+      subjectID: testSubjectID,
+      createdAt: 1462335911,
+      updatedAt: 1462335911,
+      uid: testUserID,
+      title: 'Test Topic',
+      state: 0,
+      replies: 1,
+      display: 1,
+    });
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(schema.chiiSubjectTopics)
+      .where(op.eq(schema.chiiSubjectTopics.id, testTopicID));
+  });
+
   test('should get channel blogs', async () => {
     const app = createTestServer();
     await app.register(setup);
@@ -72,6 +97,38 @@ describe('channel', () => {
     const res = await app.inject({
       method: 'get',
       url: '/channels/0/tags',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should get channel topics', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/channels/2/topics',
+      query: { limit: '10', offset: '0' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(typeof body.total).toBe('number');
+    const topic = body.data.find((t: { id: number }) => t.id === testTopicID);
+    expect(topic).toMatchObject({
+      id: testTopicID,
+      title: 'Test Topic',
+      replyCount: 1,
+      updatedAt: expect.any(Number),
+      subject: expect.objectContaining({ id: testSubjectID, type: 2 }),
+    });
+  });
+
+  test('should reject invalid channel type for topics', async () => {
+    const app = createTestServer();
+    await app.register(setup);
+    const res = await app.inject({
+      method: 'get',
+      url: '/channels/5/topics',
     });
     expect(res.statusCode).toBe(400);
   });

--- a/routes/private/routes/channel.ts
+++ b/routes/private/routes/channel.ts
@@ -1,3 +1,4 @@
+import type { Static } from 'typebox';
 import t from 'typebox';
 
 import { db, op, schema } from '@app/drizzle';
@@ -5,10 +6,25 @@ import { UnreachableError } from '@app/lib/error.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
 import { SubjectType } from '@app/lib/subject/type.ts';
 import { TagCat } from '@app/lib/tag';
+import { TopicDisplay } from '@app/lib/topic/type.ts';
 import * as convert from '@app/lib/types/convert.ts';
+import * as fetcher from '@app/lib/types/fetcher.ts';
 import * as req from '@app/lib/types/req.ts';
 import * as res from '@app/lib/types/res.ts';
 import type { App } from '@app/routes/type.ts';
+
+export type IChannelSubjectTopic = Static<typeof ChannelSubjectTopic>;
+const ChannelSubjectTopic = t.Object(
+  {
+    id: t.Integer(),
+    title: t.String(),
+    replyCount: t.Integer(),
+    updatedAt: t.Integer({ description: '最后回复时间，unix time stamp in seconds' }),
+    creator: t.Optional(res.Ref(res.SlimUser)),
+    subject: res.Ref(res.SlimSubject),
+  },
+  { $id: 'ChannelSubjectTopic', title: 'ChannelSubjectTopic' },
+);
 
 /** 频道日志关联的 tag id，与旧版 `BlogCore::FetchChlNews` 中硬编码的 `$chl_news` 映射保持一致（tag cat = `TagCat.Entry`）。 */
 const channelBlogTagIDs: Record<number, number> = {
@@ -29,6 +45,85 @@ function getChannelBlogTagID(type: number): number {
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function setup(app: App) {
+  app.addSchema(ChannelSubjectTopic);
+
+  app.get(
+    '/channels/:type/topics',
+    {
+      schema: {
+        summary: '获取频道条目讨论',
+        operationId: 'getChannelSubjectTopics',
+        tags: [Tag.Topic],
+        security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
+        params: t.Object({
+          type: req.Ref(req.SubjectType),
+        }),
+        querystring: t.Object({
+          limit: t.Optional(
+            t.Integer({ default: 20, minimum: 1, maximum: 100, description: 'max 100' }),
+          ),
+          offset: t.Optional(t.Integer({ default: 0, minimum: 0, description: 'min 0' })),
+        }),
+        response: {
+          200: res.Paged(res.Ref(ChannelSubjectTopic)),
+        },
+      },
+    },
+    async ({ auth, params: { type }, query: { limit = 20, offset = 0 } }) => {
+      const conditions = [
+        op.eq(schema.chiiSubjectTopics.display, TopicDisplay.Normal),
+        op.eq(schema.chiiSubjects.typeID, type),
+        op.ne(schema.chiiSubjects.ban, 1),
+        auth.allowNsfw ? undefined : op.eq(schema.chiiSubjects.nsfw, false),
+      ];
+      const [{ count = 0 } = {}] = await db
+        .select({ count: op.count() })
+        .from(schema.chiiSubjectTopics)
+        .innerJoin(
+          schema.chiiSubjects,
+          op.eq(schema.chiiSubjectTopics.subjectID, schema.chiiSubjects.id),
+        )
+        .where(op.and(...conditions));
+      const data = await db
+        .select()
+        .from(schema.chiiSubjectTopics)
+        .innerJoin(
+          schema.chiiSubjects,
+          op.eq(schema.chiiSubjectTopics.subjectID, schema.chiiSubjects.id),
+        )
+        .where(op.and(...conditions))
+        .orderBy(op.desc(schema.chiiSubjectTopics.updatedAt))
+        .limit(limit)
+        .offset(offset);
+      const users = await fetcher.fetchSlimUsersByIDs(data.map((d) => d.chii_subject_topics.uid));
+      const subjects = await fetcher.fetchSlimSubjectsByIDs(
+        data.map((d) => d.chii_subject_topics.subjectID),
+        auth.allowNsfw,
+      );
+      const result: IChannelSubjectTopic[] = [];
+      for (const d of data) {
+        const topic = d.chii_subject_topics;
+        const subject = subjects[topic.subjectID];
+        if (!subject) {
+          continue;
+        }
+        const item: IChannelSubjectTopic = {
+          id: topic.id,
+          title: topic.title,
+          replyCount: topic.replies,
+          updatedAt: topic.updatedAt,
+          subject,
+        };
+        const creator = users[topic.uid];
+        if (creator) {
+          item.creator = creator;
+        }
+        result.push(item);
+      }
+      return { data: result, total: count };
+    },
+  );
+
   app.get(
     '/channels/:type/blogs',
     {

--- a/routes/private/routes/trending.test.ts
+++ b/routes/private/routes/trending.test.ts
@@ -1,10 +1,39 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
+import { db, op, schema } from '@app/drizzle';
+import redis from '@app/lib/redis.ts';
+import { getTrendingSubjectTopicKey } from '@app/lib/trending/cache.ts';
+import { type TrendingItem, TrendingPeriod } from '@app/lib/trending/type';
 import { createTestServer } from '@app/tests/utils.ts';
 
 import { setup } from './trending.ts';
 
 describe('trending', () => {
+  const testTopicID = 12345670;
+  const testSubjectID = 12; // 动画
+  const testUserID = 287622;
+
+  beforeEach(async () => {
+    await db.insert(schema.chiiSubjectTopics).values({
+      id: testTopicID,
+      subjectID: testSubjectID,
+      createdAt: 1462335911,
+      updatedAt: 1462335911,
+      uid: testUserID,
+      title: 'Test Topic',
+      state: 0,
+      replies: 1,
+      display: 1,
+    });
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(schema.chiiSubjectTopics)
+      .where(op.eq(schema.chiiSubjectTopics.id, testTopicID));
+    await redis.del(getTrendingSubjectTopicKey(TrendingPeriod.Week));
+  });
+
   test('should get trending subjects', async () => {
     const app = createTestServer();
     await app.register(setup);
@@ -24,31 +53,10 @@ describe('trending', () => {
     }
   });
 
-  test('should get channel topics with type', async () => {
-    const app = createTestServer();
-    await app.register(setup);
-    const res = await app.inject({
-      method: 'get',
-      url: '/trending/subjects/topics',
-      query: { type: '2', limit: '10', offset: '0' },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = res.json();
-    expect(Array.isArray(body.data)).toBe(true);
-    expect(typeof body.total).toBe('number');
-    for (const topic of body.data) {
-      expect(topic).toMatchObject({
-        id: expect.any(Number),
-        title: expect.any(String),
-        replyCount: expect.any(Number),
-        updatedAt: expect.any(Number),
-        subject: expect.objectContaining({ type: 2 }),
-      });
-      expect('replies' in topic).toBe(false);
-    }
-  });
+  test('should get trending subject topics from cache', async () => {
+    const items: TrendingItem[] = [{ id: testTopicID, total: 1 }];
+    await redis.set(getTrendingSubjectTopicKey(TrendingPeriod.Week), JSON.stringify(items));
 
-  test('should get all topics without type', async () => {
     const app = createTestServer();
     await app.register(setup);
     const res = await app.inject({
@@ -59,27 +67,29 @@ describe('trending', () => {
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(Array.isArray(body.data)).toBe(true);
-    expect(typeof body.total).toBe('number');
-    for (const topic of body.data) {
-      expect(topic).toMatchObject({
-        id: expect.any(Number),
-        title: expect.any(String),
-        replyCount: expect.any(Number),
-        updatedAt: expect.any(Number),
-        subject: expect.any(Object),
-      });
-      expect('replies' in topic).toBe(false);
-    }
+    expect(body.total).toBe(1);
+    const topic = body.data[0];
+    expect(topic).toMatchObject({
+      id: testTopicID,
+      title: 'Test Topic',
+      replyCount: 1,
+      creatorID: testUserID,
+      parentID: testSubjectID,
+      subject: expect.objectContaining({ id: testSubjectID, type: 2 }),
+      creator: expect.objectContaining({ id: testUserID }),
+    });
+    expect(Array.isArray(topic.replies)).toBe(true);
   });
 
-  test('should reject invalid subject type', async () => {
+  test('should return empty list when cache is missing', async () => {
     const app = createTestServer();
     await app.register(setup);
     const res = await app.inject({
       method: 'get',
       url: '/trending/subjects/topics',
-      query: { type: '5' },
+      query: { limit: '10', offset: '0' },
     });
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ data: [], total: 0 });
   });
 });

--- a/routes/private/routes/trending.ts
+++ b/routes/private/routes/trending.ts
@@ -1,11 +1,9 @@
 import type { Static } from 'typebox';
 import t from 'typebox';
 
-import { db, op, schema } from '@app/drizzle';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
 import redis from '@app/lib/redis';
-import { TopicDisplay } from '@app/lib/topic/type.ts';
-import { getTrendingSubjectKey } from '@app/lib/trending/cache.ts';
+import { getTrendingSubjectKey, getTrendingSubjectTopicKey } from '@app/lib/trending/cache.ts';
 import { type TrendingItem, TrendingPeriod } from '@app/lib/trending/type';
 import * as fetcher from '@app/lib/types/fetcher.ts';
 import * as req from '@app/lib/types/req.ts';
@@ -21,23 +19,9 @@ const TrendingSubject = t.Object(
   { $id: 'TrendingSubject' },
 );
 
-export type IChannelSubjectTopic = Static<typeof ChannelSubjectTopic>;
-const ChannelSubjectTopic = t.Object(
-  {
-    id: t.Integer(),
-    title: t.String(),
-    replyCount: t.Integer(),
-    updatedAt: t.Integer({ description: '最后回复时间，unix time stamp in seconds' }),
-    creator: t.Optional(res.Ref(res.SlimUser)),
-    subject: res.Ref(res.SlimSubject),
-  },
-  { $id: 'ChannelSubjectTopic', title: 'ChannelSubjectTopic' },
-);
-
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function setup(app: App) {
   app.addSchema(TrendingSubject);
-  app.addSchema(ChannelSubjectTopic);
 
   app.get(
     '/trending/subjects',
@@ -89,76 +73,59 @@ export async function setup(app: App) {
     '/trending/subjects/topics',
     {
       schema: {
-        summary: '获取条目讨论',
+        summary: '获取热门条目讨论',
         operationId: 'getTrendingSubjectTopics',
         tags: [Tag.Trending],
         security: [{ [Security.CookiesSession]: [], [Security.HTTPBearer]: [] }],
         querystring: t.Object({
-          type: t.Optional(req.Ref(req.SubjectType)),
           limit: t.Optional(
             t.Integer({ default: 20, minimum: 1, maximum: 100, description: 'max 100' }),
           ),
           offset: t.Optional(t.Integer({ default: 0, minimum: 0, description: 'min 0' })),
         }),
         response: {
-          200: res.Paged(res.Ref(ChannelSubjectTopic)),
+          200: res.Paged(res.Ref(res.SubjectTopic)),
         },
       },
     },
-    async ({ auth, query: { type, limit = 20, offset = 0 } }) => {
-      const conditions = [
-        op.eq(schema.chiiSubjectTopics.display, TopicDisplay.Normal),
-        op.ne(schema.chiiSubjects.ban, 1),
-        auth.allowNsfw ? undefined : op.eq(schema.chiiSubjects.nsfw, false),
-      ];
-      if (type !== undefined) {
-        conditions.push(op.eq(schema.chiiSubjects.typeID, type));
+    async ({ auth, query: { limit = 20, offset = 0 } }) => {
+      const cacheKey = getTrendingSubjectTopicKey(TrendingPeriod.Week);
+      const cached = await redis.get(cacheKey);
+      if (!cached) {
+        return { data: [], total: 0 };
       }
-      const [{ count = 0 } = {}] = await db
-        .select({ count: op.count() })
-        .from(schema.chiiSubjectTopics)
-        .innerJoin(
-          schema.chiiSubjects,
-          op.eq(schema.chiiSubjectTopics.subjectID, schema.chiiSubjects.id),
-        )
-        .where(op.and(...conditions));
-      const data = await db
-        .select()
-        .from(schema.chiiSubjectTopics)
-        .innerJoin(
-          schema.chiiSubjects,
-          op.eq(schema.chiiSubjectTopics.subjectID, schema.chiiSubjects.id),
-        )
-        .where(op.and(...conditions))
-        .orderBy(op.desc(schema.chiiSubjectTopics.updatedAt))
-        .limit(limit)
-        .offset(offset);
-      const users = await fetcher.fetchSlimUsersByIDs(data.map((d) => d.chii_subject_topics.uid));
+      const ids = JSON.parse(cached) as TrendingItem[];
+      const items = ids.slice(offset, offset + limit);
+      const topics = await fetcher.fetchSubjectTopicsByIDs(items.map((item) => item.id));
       const subjects = await fetcher.fetchSlimSubjectsByIDs(
-        data.map((d) => d.chii_subject_topics.subjectID),
+        Object.values(topics).map((topic) => topic.parentID),
         auth.allowNsfw,
       );
-      const result: IChannelSubjectTopic[] = [];
-      for (const d of data) {
-        const topic = d.chii_subject_topics;
-        const subject = subjects[topic.subjectID];
+      const users = await fetcher.fetchSlimUsersByIDs(
+        Object.values(topics).map((topic) => topic.creatorID),
+      );
+      const data = [];
+      for (const item of items) {
+        const topic = topics[item.id];
+        if (!topic) {
+          continue;
+        }
+        const subject = subjects[topic.parentID];
         if (!subject) {
           continue;
         }
-        const item: IChannelSubjectTopic = {
-          id: topic.id,
-          title: topic.title,
-          replyCount: topic.replies,
-          updatedAt: topic.updatedAt,
-          subject,
-        };
-        const creator = users[topic.uid];
-        if (creator) {
-          item.creator = creator;
+        const creator = users[topic.creatorID];
+        if (!creator) {
+          continue;
         }
-        result.push(item);
+        data.push({
+          ...topic,
+          subject,
+          creator,
+          replies: [],
+        });
       }
-      return { data: result, total: count };
+      return { data, total: ids.length };
     },
   );
 }


### PR DESCRIPTION
## Summary

- Add new `GET /p1/channels/:type/topics` API to list subject topics for a channel type (anime/book/music/game), ordered by last reply time, queried directly from DB.
- Rework `GET /p1/trending/subjects/topics` to read weekly trending subject topics from the Redis cache instead of querying DB directly. The `type` query param is removed, and the response now returns full `SubjectTopic` (with `creator`, `subject`, `replies`).
- Move `ChannelSubjectTopic` schema from `trending` route to `channel` route.
- Update tests and regenerate `openapi.json`.

## Notes

- `GET /p1/trending/subjects/topics` returns `{ data: [], total: 0 }` when the cache is missing or expired.
